### PR TITLE
update news side menu

### DIFF
--- a/src/components/DesignTheme/View/Commons/SideMenu.jsx
+++ b/src/components/DesignTheme/View/Commons/SideMenu.jsx
@@ -47,7 +47,7 @@ const SideMenu = () => {
               <ul className="link-list">
                 <li className="nav-item active">
                   <a className="nav-link active" href="#text-body">
-                    <span>Notizia</span>
+                    <span>Contenuto</span>
                   </a>
                 </li>
                 <li className="nav-item">

--- a/src/components/DesignTheme/View/Commons/SideMenu.jsx
+++ b/src/components/DesignTheme/View/Commons/SideMenu.jsx
@@ -46,13 +46,13 @@ const SideMenu = () => {
               <h3 className="no_toc">Indice della pagina</h3>
               <ul className="link-list">
                 <li className="nav-item active">
-                  <a className="nav-link active" href="#descrizione">
-                    <span>Descrizione</span>
+                  <a className="nav-link active" href="#text-body">
+                    <span>Notizia</span>
                   </a>
                 </li>
                 <li className="nav-item">
                   <a className="nav-link" href="#documenti">
-                    <span>Documenti</span>
+                    <span>Allegati</span>
                   </a>
                 </li>
                 <li className="nav-item">
@@ -62,7 +62,7 @@ const SideMenu = () => {
                 </li>
                 <li className="nav-item">
                   <a className="nav-link" href="#ulteriori-informazioni">
-                    <span>Ulteriori informazioni</span>
+                    <span>Altre informazioni</span>
                   </a>
                 </li>
               </ul>

--- a/src/components/DesignTheme/View/NewsItemView.jsx
+++ b/src/components/DesignTheme/View/NewsItemView.jsx
@@ -106,7 +106,7 @@ const NewsItemView = ({ content, location }) => {
             ) : null}
             {content.dataset_correlati?.length > 0 ? (
               <article
-                id="related-items"
+                id="related-dataset"
                 className="it-page-section anchor-offset mt-5"
               >
                 <h4>Dataset</h4>


### PR DESCRIPTION
Questa PR da una sistemata al menu laterale puntando correttamente le ancore e correggendo le label per fare uno statico più conforme alla realtà. Il primo link "descrizione" l'ho cambiato con "Notizia" e punta alla sezione a blocchi