### PR TITLE
Fix problema del copia/incolla di testo

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,8 @@ import {
   addonReducers as defaultAddonReducers,
 } from '@plone/volto/config';
 
+import ToHTMLRenderers from '@plone/volto/config/RichTextEditor/ToHTML';
+
 import createInlineStyleButton from 'draft-js-buttons/lib/utils/createInlineStyleButton';
 import createBlockStyleButton from 'draft-js-buttons/lib/utils/createBlockStyleButton';
 import { Separator } from 'draft-js-inline-toolbar-plugin';
@@ -180,6 +182,17 @@ export const settings = {
   isMultilingual: false,
   supportedLanguages: ['it'],
   defaultLanguage: 'it',
+  //TODO: rimuovere questa customizzazione quando sistemano https://github.com/plone/volto/issues/1601
+  ToHTMLRenderers: {
+    ...ToHTMLRenderers,
+    blocks: {
+      ...ToHTMLRenderers.blocks,
+      blockquote: (children, { keys }) =>
+        children.map((child, i) => (
+          <blockquote key={keys[i]}>{child}</blockquote>
+        )),
+    },
+  },
 };
 
 export const views = {
@@ -187,7 +200,7 @@ export const views = {
   contentTypesViews: {
     ...defaultViews.contentTypesViews,
     'News Item': NewsItemView,
-    'UnitaOrganizzativa': UOView,
+    UnitaOrganizzativa: UOView,
     Persona: PersonaView,
     Servizio: ServizioView,
     'Pagina Argomento': PaginaArgomentoView,


### PR DESCRIPTION
Questo fix sistema il problema in maniera "dirty".

dirty perché [l'originale](https://github.com/plone/volto/blob/master/src/config/RichTextEditor/ToHTML.jsx#L121) gestisce anche il fatto che nel testo ci sia un a capo (shift+invio).
Quella gestione però si spacca se nel testo del blockquote ci sono delle parole con stili aggiuntivi (ad esempio BOLD).

Ho aperto una issue perché mi sfugge la logica con cui dovrebbe essere fatta questa cosa, e aspetto news da loro: https://github.com/plone/volto/issues/1601

Intanto possiamo usare questa customizzazione. L'unico side-effect è che non disegna l'a capo per ora, ma almeno non si spacca.