### PR TITLE
change template to use the new design_italia_meta_type to detect content type

### DIFF
--- a/src/components/DesignTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/DesignTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -48,7 +48,7 @@ const InEvidenceTemplate = ({ items, title, isEditMode }) => {
               <CardCategory
                 date={item.effective && moment(item.effective).format('ll')}
               >
-                {item.subjects?.join(', ')}
+                {item?.design_italia_meta_type}
               </CardCategory>
               <CardTitle tag="h4">
                 <Link to={flattenToAppURL(item['@id'])}>

--- a/src/components/DesignTheme/Blocks/Listing/NewsTemplate.jsx
+++ b/src/components/DesignTheme/Blocks/Listing/NewsTemplate.jsx
@@ -58,7 +58,7 @@ const NewsTemplate = ({ items, isEditMode, title, linkMore }) => {
                 <CardCategory
                   date={item.effective && moment(item.effective).format('ll')}
                 >
-                  {item.subjects?.join(', ')}
+                  {item?.design_italia_meta_type}
                 </CardCategory>
                 <CardTitle tag="h4">
                   <Link to={flattenToAppURL(item['@id'])}>

--- a/theme/DesignTheme/Blocks/_newstemplate.scss
+++ b/theme/DesignTheme/Blocks/_newstemplate.scss
@@ -1,4 +1,5 @@
-.block.listing .news-template {
+.block.listing .news-template,
+.block.listing .in-evidence {
   .col-item {
     margin-bottom: 22px;
   }


### PR DESCRIPTION
eg. for news return the 'tipologia_notizia' value
this is strictly related to https://github.com/RedTurtle/design.plone.contenttypes/pull/20

Nicola and Giulia I also assign this pr to you 'cause most of the templates on design-volto-theme are yours and you need to know this change.