### PR TITLE
fixed z-index for react_select menu

### DIFF
--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -16,4 +16,8 @@ body.cms-ui {
   .it-footer {
     display: none;
   }
+
+  .react-select__menu {
+    z-index: 11;
+  }
 }


### PR DESCRIPTION
Fix del problema del widget della tipologia (select) che quando la si apre va sotto al datepicker. c'è un esempio nel Ct Persona