### PR TITLE
fixed searchSection block styles

### DIFF
--- a/src/components/ItaliaTheme/Blocks/SearchSections/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/SearchSections/Body.jsx
@@ -29,56 +29,47 @@ const Body = ({ block, sections }) => {
   const intl = useIntl();
   moment.locale(intl.locale);
   return (
-    <Row>
-      <div className="public-ui searchServices">
-        <div className="container">
-          <div>
-            <h2 className="text-white">{block.title}</h2>
+    <div className="public-ui searchSections">
+      <div className="container">
+        <div>
+          <h2 className="text-white">{block.title}</h2>
+        </div>
+        <div className="searchContainer d-flex w-100">
+          <div className="searchbar lightgrey-bg-c2 shadow-sm rounded d-flex w-100">
+            <input
+              className="inputSearch lightgrey-bg-c2"
+              type="text"
+              placeholder={block.placeholder}
+              onChange={(e) => setInputText(e.currentTarget.value)}
+              onKeyDown={(e) =>
+                e.key === 'Enter' ? navigate(inputText, searchFilters()) : null
+              }
+            ></input>
+            <button
+              className="rounded-right"
+              onClick={(e) => navigate(inputText, searchFilters())}
+            >
+              <Icon icon="it-search" padding={false} size="sm" color="white" />
+            </button>
           </div>
-          <div className="searchContainer d-flex w-100">
-            <div className="searchbar lightgrey-bg-c2 shadow-sm rounded d-flex w-100">
-              <input
-                className="inputSearch lightgrey-bg-c2"
-                type="text"
-                placeholder={block.placeholder}
-                onChange={(e) => setInputText(e.currentTarget.value)}
-                onKeyDown={(e) =>
-                  e.key === 'Enter'
-                    ? navigate(inputText, searchFilters())
-                    : null
-                }
-              ></input>
-              <button
-                className="rounded-right"
-                onClick={(e) => navigate(inputText, searchFilters())}
-              >
-                <Icon
-                  icon="it-search"
-                  padding={false}
+          <div className="buttonsContainer mt-2 d-flex">
+            {block.links?.map((link, index) => {
+              return (
+                <Button
+                  color="primary"
+                  tag="button"
                   size="sm"
-                  color="white"
-                />
-              </button>
-            </div>
-            <div className="buttonsContainer mt-2 d-flex">
-              {block.links?.map((link, index) => {
-                return (
-                  <Button
-                    color="primary"
-                    tag="button"
-                    size="sm"
-                    key={index}
-                    onClick={() => handleClick(link)}
-                  >
-                    {link.title}
-                  </Button>
-                );
-              })}
-            </div>
+                  key={index}
+                  onClick={() => handleClick(link)}
+                >
+                  {link.title}
+                </Button>
+              );
+            })}
           </div>
         </div>
       </div>
-    </Row>
+    </div>
   );
 };
 

--- a/theme/ItaliaTheme/Blocks/_searchSections.scss
+++ b/theme/ItaliaTheme/Blocks/_searchSections.scss
@@ -1,7 +1,7 @@
 .container .block {
   height: auto;
 
-  .row .searchServices {
+  .searchSections {
     width: 100%;
     min-height: 280px;
     height: auto;

--- a/theme/site.scss
+++ b/theme/site.scss
@@ -22,7 +22,7 @@
 @import 'ItaliaTheme/Blocks/alert';
 @import 'ItaliaTheme/Blocks/titolo_argomento';
 @import 'ItaliaTheme/Blocks/newshome';
-@import 'ItaliaTheme/Blocks/searchServices';
+@import 'ItaliaTheme/Blocks/searchSections';
 @import 'ItaliaTheme/Blocks/newstemplate';
 @import 'ItaliaTheme/Blocks/smallblockLinkstemplate';
 @import 'ItaliaTheme/Blocks/completeBlockLinkstemplate';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,9 +1252,9 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.9.2":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.0.tgz#f10245877042a815e07f7e693faff0ae9d3a2aac"
-  integrity sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 


### PR DESCRIPTION
Sistemati gli stili del blocco di ricerca delle sezioni, perchè era wrappato da un raw (a quanto pare inutile in quel caso) che provocava lo scorrimento orizzontale della pagina.
Cambiati anche il nome del file css e della classe del blocco in modo da uniformarli al nome del blocco (da searchServices a searchSections)