### PR TITLE
[dev] rimossa card evento supportato da se organizzatore esterno

### DIFF
--- a/src/components/ItaliaTheme/View/EventoView.jsx
+++ b/src/components/ItaliaTheme/View/EventoView.jsx
@@ -284,19 +284,6 @@ const EventoView = ({ content, location }) => {
                     )}
                   </CardBody>
                 </Card>
-                {content?.evento_supportato_da?.length > 0 && (
-                  <>
-                    <h5 className="mt-4 supported-by">Con il supporto di:</h5>
-                    {content?.evento_supportato_da?.map((item) => (
-                      <OfficeCard
-                        key={item['@id']}
-                        office={item}
-                        extended={true}
-                        icon={'it-pa'}
-                      />
-                    ))}
-                  </>
-                )}
               </article>
             ) : null}
 


### PR DESCRIPTION
Se l'organizzatore e' esterno, non mostriamo piu' le info relative a chi supporta l'evento, anche se il campo e' compilato