### PR TITLE
Fix Pagination data counts

### DIFF
--- a/src/customizations/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/customizations/components/manage/Blocks/Listing/ListingBody.jsx
@@ -94,8 +94,7 @@ const ListingBody = ({ data, properties, intl, path, isEditMode }) => {
                 <Pagination
                   activePage={currentPage}
                   totalPages={Math.ceil(
-                    querystringResults[data.block].total /
-                      (data.b_size || settings.defaultPageSize),
+                    content.items_total / settings.defaultPageSize,
                   )}
                   onPageChange={handleQueryPaginationChange}
                 />


### PR DESCRIPTION
Il pezzo modificato è relativo ai contenuti folderish e non segue i parametri della querystring.
Immagino fosse figlio di un copia incolla, su volto il calcolo è corretto e l'ho ripristinato 