### PR TITLE
added dropdown icon for megamenu

### DIFF
--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -177,6 +177,10 @@ const MegaMenu = ({ item, pathname }) => {
         >
           <DropdownToggle aria-haspopup color="secondary" nav>
             {item.title}
+            <Icon
+              icon="it-expand"
+              className={cx('megamenu-toggle-icon', { open: menuStatus })}
+            />
           </DropdownToggle>
           <DropdownMenu flip tag="div">
             <Row>

--- a/theme/bootstrap-override/bootstrap-italia/_megamenu.scss
+++ b/theme/bootstrap-override/bootstrap-italia/_megamenu.scss
@@ -71,3 +71,20 @@
     }
   }
 }
+
+.megamenu {
+  .megamenu-toggle-icon {
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-left: 0.5rem;
+    fill: #fff;
+    line-height: 1;
+    transform: rotateX(0);
+    transition: transform 0.3s ease;
+
+    &.open {
+      transform: rotateX(180deg);
+    }
+  }
+}

--- a/theme/bootstrap-override/bootstrap-italia/_megamenu.scss
+++ b/theme/bootstrap-override/bootstrap-italia/_megamenu.scss
@@ -86,5 +86,29 @@
     &.open {
       transform: rotateX(180deg);
     }
+
+    @media (max-width: 991px) {
+      fill: $primary;
+    }
+  }
+
+  @media (min-width: 992px) {
+    .dropdown.show {
+      > a.nav-link[aria-expanded='true'] {
+        position: relative;
+
+        &::after {
+          position: absolute;
+          bottom: -5px;
+          left: calc(50% - 10px);
+          width: 0;
+          height: 0;
+          border-width: 0 10px 10px;
+          border-style: solid;
+          border-color: transparent transparent #fff;
+          content: '';
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Aggiunge:

- icone nei bottoni di toggle dei dropdown
- stile per "triangolino" di indicazione del dropdown aperto

<img width="1369" alt="Schermata 2020-10-02 alle 10 28 04" src="https://user-images.githubusercontent.com/21101435/94903641-64f22e80-049a-11eb-94c1-7bc35e04bd3a.png">
