### PR TITLE
added PlaceholderAfterContent for each view

### DIFF
--- a/src/components/ItaliaTheme/View/EventoView/EventoView.jsx
+++ b/src/components/ItaliaTheme/View/EventoView/EventoView.jsx
@@ -25,7 +25,9 @@ import {
   Sponsors,
   RelatedItems,
   RichText,
+  EventoPlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
+
 import { Link } from 'react-router-dom';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import {
@@ -482,6 +484,7 @@ const EventoView = ({ content, location }) => {
           </section>
         </div>
       </div>
+      <EventoPlaceholderAfterContent />
       <RelatedItems content={content} />
     </>
   );

--- a/src/components/ItaliaTheme/View/EventoView/Placeholder/AfterContent.jsx
+++ b/src/components/ItaliaTheme/View/EventoView/Placeholder/AfterContent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const AfterContent = () => {
+  return <></>;
+};
+export default AfterContent;

--- a/src/components/ItaliaTheme/View/NewsItemView/NewsItemView.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/NewsItemView.jsx
@@ -6,7 +6,7 @@
 import React, { createRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
-import { readingTime } from './ViewUtils';
+import { readingTime } from '../ViewUtils';
 
 import {
   Metadata,
@@ -20,6 +20,7 @@ import {
   Attachments,
   TextOrBlocks,
   RelatedItems,
+  NewsItemPlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
 
 // import { getBaseUrl } from '@plone/volto/helpers';
@@ -143,6 +144,7 @@ const NewsItemView = ({ content, location }) => {
           </section>
         </div>
       </div>
+      <NewsItemPlaceholderAfterContent />
       <RelatedItems list={related_items} />
     </>
   );

--- a/src/components/ItaliaTheme/View/NewsItemView/Placeholder/AfterContent.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/Placeholder/AfterContent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const AfterContent = () => {
+  return <></>;
+};
+export default AfterContent;

--- a/src/components/ItaliaTheme/View/PageView/PageView.jsx
+++ b/src/components/ItaliaTheme/View/PageView/PageView.jsx
@@ -16,6 +16,7 @@ import {
   SearchSectionForm,
   PageHeaderNav,
   RelatedItems,
+  PagePlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
 import { defineMessages, useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
@@ -117,6 +118,7 @@ const PageView = ({ content }) => {
           )}
         </Container>
       )}
+      <PagePlaceholderAfterContent />
       <RelatedItems content={content} />
     </>
   );

--- a/src/components/ItaliaTheme/View/PageView/Placeholder/AfterContent.jsx
+++ b/src/components/ItaliaTheme/View/PageView/Placeholder/AfterContent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const AfterContent = () => {
+  return <></>;
+};
+export default AfterContent;

--- a/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView.jsx
+++ b/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView.jsx
@@ -1,6 +1,6 @@
 /**
  * PaginaArgomentoView view component.
- * @module components/theme/View/PaginaArgomentoView
+ * @module components/theme/View/PaginaArgomentoView/PaginaArgomentoView
  */
 
 import React, { useEffect } from 'react';
@@ -26,7 +26,10 @@ import { getContent, resetContent } from '@plone/volto/actions';
 import { useDispatch, useSelector } from 'react-redux';
 import { Portal } from 'react-portal';
 import { BodyClass } from '@plone/volto/helpers';
-import { ArgumentIcon } from '@italia/components/ItaliaTheme/View';
+import {
+  ArgumentIcon,
+  PaginaArgomentoPlaceholderAfterContent,
+} from '@italia/components/ItaliaTheme/View';
 
 /**
  * PaginaArgomentoView view component class.
@@ -161,6 +164,8 @@ const PaginaArgomentoView = ({ content }) => {
           </div>
         );
       })}
+
+      <PaginaArgomentoPlaceholderAfterContent />
     </div>
   ) : (
     <PaginaArgomentoViewNoBlocks content={content} />

--- a/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks.jsx
+++ b/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks.jsx
@@ -15,6 +15,7 @@ import {
   RichTextArticle,
   Metadata,
   NewsCard,
+  PaginaArgomentoPlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
 
 // import { getBaseUrl } from '@plone/volto/helpers';
@@ -228,6 +229,7 @@ const PaginaArgomentoViewNoBlocks = ({ content }) => {
             <Metadata content={content} />
           </section>
         </div>
+        <PaginaArgomentoPlaceholderAfterContent />
       </div>
     </>
   );

--- a/src/components/ItaliaTheme/View/PaginaArgomentoView/Placeholder/AfterContent.jsx
+++ b/src/components/ItaliaTheme/View/PaginaArgomentoView/Placeholder/AfterContent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const AfterContent = () => {
+  return <></>;
+};
+export default AfterContent;

--- a/src/components/ItaliaTheme/View/PersonaView/PersonaView.jsx
+++ b/src/components/ItaliaTheme/View/PersonaView/PersonaView.jsx
@@ -1,6 +1,6 @@
 /**
- * NewsItemView view component.
- * @module components/theme/View/NewsItemView
+ * PersonaView view component.
+ * @module components/theme/View/PersonaView
  */
 
 import React, { createRef, useEffect, useState } from 'react';
@@ -19,6 +19,7 @@ import {
   Metadata,
   HelpBox,
   RelatedItems,
+  PersonaPlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
 import { contentFolderHasItems } from '@italia/helpers';
 
@@ -432,6 +433,7 @@ const PersonaView = ({ content }) => {
           </section>
         </div>
       </div>
+      <PersonaPlaceholderAfterContent />
       <RelatedItems content={content} />
     </>
   );

--- a/src/components/ItaliaTheme/View/PersonaView/Placeholder/AfterContent.jsx
+++ b/src/components/ItaliaTheme/View/PersonaView/Placeholder/AfterContent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const AfterContent = () => {
+  return <></>;
+};
+export default AfterContent;

--- a/src/components/ItaliaTheme/View/ServizioView/Placeholder/AfterContent.jsx
+++ b/src/components/ItaliaTheme/View/ServizioView/Placeholder/AfterContent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const AfterContent = () => {
+  return <></>;
+};
+export default AfterContent;

--- a/src/components/ItaliaTheme/View/ServizioView/ServizioView.jsx
+++ b/src/components/ItaliaTheme/View/ServizioView/ServizioView.jsx
@@ -1,6 +1,6 @@
 /**
- * NewsItemView view component.
- * @module components/theme/View/NewsItemView
+ * ServizioView view component.
+ * @module components/theme/View/ServizioView
  */
 
 import React, { createRef, useEffect, useState } from 'react';
@@ -19,6 +19,7 @@ import {
   SmallVenue,
   HelpBox,
   NewsCard,
+  ServizioPlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
 
 import { Card, CardBody } from 'design-react-kit/dist/design-react-kit';
@@ -129,8 +130,8 @@ const messages = defineMessages({
 });
 
 /**
- * PersonaView view component class.
- * @function PersonaView
+ * ServizioView view component class.
+ * @function ServizioView
  * @params {object} content Content object.
  * @returns {string} Markup of the component.
  */
@@ -487,6 +488,7 @@ const ServizioView = ({ content }) => {
           </section>
         </div>
       </div>
+      <ServizioPlaceholderAfterContent />
     </>
   );
 };

--- a/src/components/ItaliaTheme/View/UOView/Placeholder/AfterContent.jsx
+++ b/src/components/ItaliaTheme/View/UOView/Placeholder/AfterContent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const AfterContent = () => {
+  return <></>;
+};
+export default AfterContent;

--- a/src/components/ItaliaTheme/View/UOView/UOView.jsx
+++ b/src/components/ItaliaTheme/View/UOView/UOView.jsx
@@ -20,6 +20,7 @@ import {
   RelatedItems,
   SideMenu,
   WideImage,
+  UOPlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
 
 import { Chip, ChipLabel } from 'design-react-kit/dist/design-react-kit';
@@ -105,7 +106,7 @@ const messages = defineMessages({
 
 /**
  * UOView view component class.
- * @function NewsItemView
+ * @function UOView
  * @params {object} content Content object.
  * @returns {string} Markup of the component.
  */
@@ -442,7 +443,7 @@ const UOView = ({ content }) => {
           </section>
         </div>
       </div>
-
+      <UOPlaceholderAfterContent />
       <RelatedItems content={content} list={content?.related_news ?? []} />
     </>
   );

--- a/src/components/ItaliaTheme/View/VenueView/Placeholder/AfterContent.jsx
+++ b/src/components/ItaliaTheme/View/VenueView/Placeholder/AfterContent.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const AfterContent = () => {
+  return <></>;
+};
+export default AfterContent;

--- a/src/components/ItaliaTheme/View/VenueView/VenueView.jsx
+++ b/src/components/ItaliaTheme/View/VenueView/VenueView.jsx
@@ -1,6 +1,6 @@
 /**
- * NewsItemView view component.
- * @module components/theme/View/NewsItemView
+ * VenueView view component.
+ * @module components/theme/View/VenueView
  */
 
 import React, { createRef, useEffect, useState } from 'react';
@@ -18,6 +18,7 @@ import {
   Gallery,
   GenericCard,
   Metadata,
+  VenuePlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
 import { contentFolderHasItems } from '@italia/helpers';
 import { Icon } from 'design-react-kit/dist/design-react-kit';
@@ -520,6 +521,7 @@ const VenueView = ({ content }) => {
           </section>
         </div>
       </div>
+      <VenuePlaceholderAfterContent />
       <RelatedItems list={content.related_news ?? []} />
     </>
   );

--- a/src/components/ItaliaTheme/View/__tests__/EventoView.test.jsx
+++ b/src/components/ItaliaTheme/View/__tests__/EventoView.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import EventoView from '../EventoView';
+import EventoView from '../EventoView/EventoView';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/components/ItaliaTheme/View/__tests__/PaginaArgomento.test.jsx
+++ b/src/components/ItaliaTheme/View/__tests__/PaginaArgomento.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import PaginaArgomentoView from '../PaginaArgomentoView';
+import PaginaArgomentoView from '../PaginaArgomentoView/PaginaArgomentoView';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/components/ItaliaTheme/View/__tests__/PersonaView.test.jsx
+++ b/src/components/ItaliaTheme/View/__tests__/PersonaView.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, waitForElement } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import PersonaView from '../PersonaView';
+import PersonaView from '../PersonaView/PersonaView';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-intl-redux';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/components/ItaliaTheme/View/index.js
+++ b/src/components/ItaliaTheme/View/index.js
@@ -40,4 +40,12 @@ export Sponsors from '@italia/components/ItaliaTheme/View/Commons/Sponsors';
 export RelatedItems from '@italia/components/ItaliaTheme/View/Commons/RelatedItems';
 
 /* --- View --- */
-export PaginaArgomentoViewNoBlocks from '@italia/components/ItaliaTheme/View/PaginaArgomentoViewNoBlocks';
+export PaginaArgomentoViewNoBlocks from '@italia/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks';
+export EventoPlaceholderAfterContent from '@italia/components/ItaliaTheme/View/EventoView/Placeholder/AfterContent';
+export NewsItemPlaceholderAfterContent from '@italia/components/ItaliaTheme/View/NewsItemView/Placeholder/AfterContent';
+export PagePlaceholderAfterContent from '@italia/components/ItaliaTheme/View/PageView/Placeholder/AfterContent';
+export PaginaArgomentoPlaceholderAfterContent from '@italia/components/ItaliaTheme/View/PaginaArgomentoView/Placeholder/AfterContent';
+export PersonaPlaceholderAfterContent from '@italia/components/ItaliaTheme/View/PersonaView/Placeholder/AfterContent';
+export ServizioPlaceholderAfterContent from '@italia/components/ItaliaTheme/View/ServizioView/Placeholder/AfterContent';
+export UOPlaceholderAfterContent from '@italia/components/ItaliaTheme/View/UOView/Placeholder/AfterContent';
+export VenuePlaceholderAfterContent from '@italia/components/ItaliaTheme/View/VenueView/Placeholder/AfterContent';

--- a/src/components/ItaliaTheme/index.js
+++ b/src/components/ItaliaTheme/index.js
@@ -42,14 +42,14 @@ export SectionIcon from '@italia/components/ItaliaTheme/Icons/SectionIcon';
 
 export CharCounterDescriptionWidget from '@italia/components/ItaliaTheme/manage/Widgets/CharCounterDescriptionWidget';
 export TextEditorWidget from '@italia/components/ItaliaTheme/manage/Widgets/TextEditorWidget';
-export PageView from '@italia/components/ItaliaTheme/View/PageView';
-export VenueView from '@italia/components/ItaliaTheme/View/VenueView';
-export NewsItemView from '@italia/components/ItaliaTheme/View/NewsItemView';
-export UOView from '@italia/components/ItaliaTheme/View/UOView';
-export PersonaView from '@italia/components/ItaliaTheme/View/PersonaView';
-export ServizioView from '@italia/components/ItaliaTheme/View/ServizioView';
-export EventoView from '@italia/components/ItaliaTheme/View/EventoView';
-export PaginaArgomentoView from '@italia/components/ItaliaTheme/View/PaginaArgomentoView';
+export PageView from '@italia/components/ItaliaTheme/View/PageView/PageView';
+export VenueView from '@italia/components/ItaliaTheme/View/VenueView/VenueView';
+export NewsItemView from '@italia/components/ItaliaTheme/View/NewsItemView/NewsItemView';
+export UOView from '@italia/components/ItaliaTheme/View/UOView/UOView';
+export PersonaView from '@italia/components/ItaliaTheme/View/PersonaView/PersonaView';
+export ServizioView from '@italia/components/ItaliaTheme/View/ServizioView/ServizioView';
+export EventoView from '@italia/components/ItaliaTheme/View/EventoView/EventoView';
+export PaginaArgomentoView from '@italia/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoView';
 
 export LinkToWidget from '@italia/components/ItaliaTheme/manage/Widgets/LinkToWidget';
 export IconWidget from '@italia/components/ItaliaTheme/manage/Widgets/IconWidget';


### PR DESCRIPTION
L'idea è quella di avere dei 'segnaposto' dove poter inserire contenuti custom per il comune per ogni view.
Per il momento è stato creato solamente il componente 'AfterContent' che mette un segnaposto dopo il contenuto. Ma in futuro potrebbe essere necessario avere altri segnaposto in altre posizioni della view, per questo motivo è stata creata una cartellina 'Placeholder' per ogni view.

Io e @nzambello abbiamo anche in mente di creare nei prossimi giorni, dei componenti separati per ogni pezzo della view, in modo da poter customizzare in maniera più semplice e meno invasiva le view dei contenttype.
