### PR TITLE
customizable content image position: afterHeader (default) or documen…

### DIFF
--- a/src/components/ItaliaTheme/View/Commons/ContentImage.jsx
+++ b/src/components/ItaliaTheme/View/Commons/ContentImage.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { views } from '@italia/config';
+import { WideImage } from '@italia/components/ItaliaTheme/View';
+/**
+ * ContentImage view component class.
+ * @function ContentImage
+ * @params {object} content: Content object.
+ * @returns {string} Markup of the component.
+ */
+const ContentImage = ({ content, position }) => {
+  const view =
+    (content?.image || content?.image_caption) &&
+    views.italiaThemeViewsConfig.imagePosition === position;
+
+  return view ? (
+    <WideImage
+      title={content?.title}
+      image={content?.image}
+      caption={content?.image_caption}
+      fullWidth={views.italiaThemeViewsConfig.imagePosition === 'afterHeader'}
+    />
+  ) : null;
+};
+export default ContentImage;
+
+ContentImage.propTypes = {
+  params: PropTypes.shape({
+    title: PropTypes.string,
+    image: PropTypes.shape({
+      download: PropTypes.string,
+    }),
+    caption: PropTypes.string,
+    fullWidth: PropTypes.bool,
+  }),
+};

--- a/src/components/ItaliaTheme/View/Commons/WideImage.jsx
+++ b/src/components/ItaliaTheme/View/Commons/WideImage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 /**
  * WideImage view component class.
@@ -8,21 +9,21 @@ import PropTypes from 'prop-types';
  * @params {object} content: Content object.
  * @returns {string} Markup of the component.
  */
-const WideImage = params => {
+const WideImage = ({ image, title, caption, fullWidth = true }) => {
   return (
-    <div className="row row-full-width my-3">
+    <div className={cx('row wide-image', { 'row-full-width my-3': fullWidth })}>
       <figure className="figure">
-        {params.image && (
+        {image && (
           <img
-            src={flattenToAppURL(params.image.download)}
-            className="full-width"
-            alt={params.caption || params.title}
-            title={params.caption || params.title}
+            src={flattenToAppURL(image.download)}
+            className={cx('', { 'full-width': fullWidth })}
+            alt={caption || title}
+            title={caption || title}
           />
         )}
-        {params.caption && (
+        {caption && (
           <figcaption className="figure-caption text-center pt-3">
-            {params.caption}
+            {caption}
           </figcaption>
         )}
       </figure>
@@ -38,5 +39,6 @@ WideImage.propTypes = {
       download: PropTypes.string,
     }),
     caption: PropTypes.string,
+    fullWidth: PropTypes.bool,
   }),
 };

--- a/src/components/ItaliaTheme/View/EventoView/EventoView.jsx
+++ b/src/components/ItaliaTheme/View/EventoView/EventoView.jsx
@@ -11,7 +11,7 @@ import {
   Attachments,
   Gallery,
   Events,
-  WideImage,
+  ContentImage,
   SideMenu,
   HelpBox,
   PageHeader,
@@ -156,6 +156,7 @@ const EventoView = ({ content, location }) => {
       )
     );
   };
+
   useEffect(() => {
     if (documentBody.current) {
       if (__CLIENT__) {
@@ -171,19 +172,14 @@ const EventoView = ({ content, location }) => {
           content={content}
           readingtime={null}
           showreadingtime={true}
-          imageinheader={false}
-          imageinheader_field={null}
           showdates={true}
           showtopics={true}
           showtassonomiaargomenti={true}
         />
-        {(content?.image || content?.image_caption) && (
-          <WideImage
-            title={content?.title}
-            image={content?.image}
-            caption={content?.image_caption}
-          />
-        )}
+
+        {/* HEADER IMAGE */}
+        <ContentImage content={content} position="afterHeader" />
+
         <div className="row border-top row-column-border row-column-menu-left">
           <aside className="col-lg-4">
             {__CLIENT__ && <SideMenu data={sideMenuElements} />}
@@ -192,6 +188,9 @@ const EventoView = ({ content, location }) => {
             ref={documentBody}
             className="col-lg-8 it-page-sections-container"
           >
+            {/* HEADER IMAGE */}
+            <ContentImage content={content} position="documentBody" />
+
             {/* COS'è */}
             <RichTextArticle
               tag_id={'text-body'}

--- a/src/components/ItaliaTheme/View/NewsItemView/NewsItemView.jsx
+++ b/src/components/ItaliaTheme/View/NewsItemView/NewsItemView.jsx
@@ -7,13 +7,12 @@ import React, { createRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
 import { readingTime } from '../ViewUtils';
-
 import {
   Metadata,
   RichTextArticle,
   PageHeader,
   SideMenu,
-  WideImage,
+  ContentImage,
   Locations,
   CuredBy,
   Gallery,
@@ -83,19 +82,14 @@ const NewsItemView = ({ content, location }) => {
           content={content}
           readingtime={readingtime}
           showreadingtime={true}
-          imageinheader={false}
-          imageinheader_field={null}
           showdates={true}
           showtopics={true}
           showtassonomiaargomenti={true}
         />
-        {(content.image || content.image_caption) && (
-          <WideImage
-            title={content.title}
-            image={content.image}
-            caption={content.image_caption}
-          />
-        )}
+
+        {/* HEADER IMAGE */}
+        <ContentImage content={content} position="afterHeader" />
+
         <div className="row border-top row-column-border row-column-menu-left">
           <aside className="col-lg-4">
             <SideMenu data={sideMenuElements} />
@@ -108,6 +102,10 @@ const NewsItemView = ({ content, location }) => {
               id="text-body"
               className="it-page-section anchor-offset clearfix"
             >
+              {/* HEADER IMAGE */}
+              <ContentImage content={content} position="documentBody" />
+
+              {/* TEXT OR BLOCKS */}
               <TextOrBlocks content={content} location={location} />
             </article>
 

--- a/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks.jsx
+++ b/src/components/ItaliaTheme/View/PaginaArgomentoView/PaginaArgomentoViewNoBlocks.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
 import {
   GenericCard,
-  WideImage,
+  ContentImage,
   SideMenu,
   PageHeader,
   OfficeCard,
@@ -81,18 +81,11 @@ const PaginaArgomentoViewNoBlocks = ({ content }) => {
           content={content}
           readingtime={null}
           showreadingtime={false}
-          imageinheader={false}
-          imageinheader_field={null}
           showdates={false}
           showtassonomiaargomenti={true}
         />
-        {content.image && (
-          <WideImage
-            title={content.title}
-            image={content.image}
-            caption={content.image_caption}
-          />
-        )}
+        {/* HEADER IMAGE */}
+        <ContentImage content={content} position="afterHeader" />
 
         <div className="row border-top row-column-border row-column-menu-left">
           <aside className="col-lg-4">
@@ -102,6 +95,9 @@ const PaginaArgomentoViewNoBlocks = ({ content }) => {
             className="col-lg-8 it-page-sections-container"
             ref={documentBody}
           >
+            {/* HEADER IMAGE */}
+            <ContentImage content={content} position="documentBody" />
+
             {content?.area_appartenenza?.length > 0 ? (
               <article
                 id="area_appartenenza"

--- a/src/components/ItaliaTheme/View/ServizioView/ServizioView.jsx
+++ b/src/components/ItaliaTheme/View/ServizioView/ServizioView.jsx
@@ -15,7 +15,7 @@ import {
   OfficeCard,
   GenericCard,
   Metadata,
-  WideImage,
+  ContentImage,
   SmallVenue,
   HelpBox,
   NewsCard,
@@ -155,17 +155,12 @@ const ServizioView = ({ content }) => {
           content={content}
           readingtime={null}
           showreadingtime={false}
-          imageinheader={false}
           showdates={false}
           showtassonomiaargomenti={true}
         />
-        {(content.image || content.image_caption) && (
-          <WideImage
-            title={content.title}
-            image={content.image}
-            caption={content.image_caption}
-          />
-        )}
+        {/* HEADER IMAGE */}
+        <ContentImage content={content} position="afterHeader" />
+
         <div className="row border-top row-column-border row-column-menu-left">
           <aside className="col-lg-4">
             <SideMenu data={sideMenuElements} />
@@ -174,6 +169,9 @@ const ServizioView = ({ content }) => {
             className="col-lg-8 it-page-sections-container"
             ref={documentBody}
           >
+            {/* HEADER IMAGE */}
+            <ContentImage content={content} position="documentBody" />
+
             {/* STATO DEL SERVIZIO */}
             {content.stato_servizio && content.motivo_stato_servizio?.data && (
               <RichTextArticle

--- a/src/components/ItaliaTheme/View/UOView/UOView.jsx
+++ b/src/components/ItaliaTheme/View/UOView/UOView.jsx
@@ -19,7 +19,7 @@ import {
   RelatedArticles,
   RelatedItems,
   SideMenu,
-  WideImage,
+  ContentImage,
   UOPlaceholderAfterContent,
 } from '@italia/components/ItaliaTheme/View';
 
@@ -128,18 +128,12 @@ const UOView = ({ content }) => {
           content={content}
           readingtime={null}
           showreadingtime={false}
-          imageinheader={false}
-          imageinheader_field={null}
           showdates={false}
           showtassonomiaargomenti={true}
         />
-        {content?.image && (
-          <WideImage
-            title={content.title}
-            image={content.image}
-            caption={null}
-          />
-        )}
+        {/* HEADER IMAGE */}
+        <ContentImage content={content} position="afterHeader" />
+
         <div className="row border-top row-column-border row-column-menu-left">
           <aside className="col-lg-4">
             {__CLIENT__ && <SideMenu data={sideMenuElements} />}
@@ -148,6 +142,9 @@ const UOView = ({ content }) => {
             ref={documentBody}
             className="col-lg-8 it-page-sections-container"
           >
+            {/* HEADER IMAGE */}
+            <ContentImage content={content} position="documentBody" />
+
             {/*** COSA FA ***/}
             {content?.competenze?.data?.replace(/(<([^>]+)>)/g, '') && (
               <article

--- a/src/components/ItaliaTheme/View/VenueView/VenueView.jsx
+++ b/src/components/ItaliaTheme/View/VenueView/VenueView.jsx
@@ -9,7 +9,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import {
   SideMenu,
   PageHeader,
-  WideImage,
+  ContentImage,
   RichTextArticle,
   RelatedItems,
   RelatedArticles,
@@ -155,18 +155,12 @@ const VenueView = ({ content }) => {
           content={content}
           readingtime={null}
           showreadingtime={false}
-          imageinheader={true}
-          imageinheader_field={'foto_persona'}
           showdates={false}
           showtassonomiaargomenti={true}
         />
-        {(content.image || content.image_caption) && (
-          <WideImage
-            title={content.title}
-            image={content.image}
-            caption={content.image_caption}
-          />
-        )}
+        {/* HEADER IMAGE */}
+        <ContentImage content={content} position="afterHeader" />
+
         <div className="row border-top row-column-border row-column-menu-left">
           <aside className="col-lg-4">
             {__CLIENT__ && <SideMenu data={sideMenuElements} />}
@@ -175,6 +169,9 @@ const VenueView = ({ content }) => {
             className="col-lg-8 it-page-sections-container"
             ref={documentBody}
           >
+            {/* HEADER IMAGE */}
+            <ContentImage content={content} position="documentBody" />
+
             {/* DESCRIZIONE */}
             {(content?.descrizione_completa?.data?.replace(/(<([^>]+)>)/g, '')
               .length > 0 ||

--- a/src/components/ItaliaTheme/View/index.js
+++ b/src/components/ItaliaTheme/View/index.js
@@ -31,6 +31,7 @@ export OfficeCard from '@italia/components/ItaliaTheme/View/Commons/OfficeCard';
 
 export RelatedNews from '@italia/components/ItaliaTheme/View/Commons/RelatedNews';
 export WideImage from '@italia/components/ItaliaTheme/View/Commons/WideImage';
+export ContentImage from '@italia/components/ItaliaTheme/View/Commons/ContentImage';
 export Locations from '@italia/components/ItaliaTheme/View/Commons/Locations';
 export EventLocations from '@italia/components/ItaliaTheme/View/Commons/EventLocations';
 export EventLocation from '@italia/components/ItaliaTheme/View/Commons/EventLocation';

--- a/src/config.js
+++ b/src/config.js
@@ -268,6 +268,9 @@ export const views = {
     Event: EventoView,
     'Pagina Argomento': PaginaArgomentoView,
   },
+  italiaThemeViewsConfig: {
+    imagePosition: 'afterHeader', //values: afterHeader, documentBody
+  },
 };
 
 export const widgets = {

--- a/theme/ItaliaTheme/Views/_common.scss
+++ b/theme/ItaliaTheme/Views/_common.scss
@@ -241,3 +241,18 @@ div.sticky-wrapper {
     color: $tertiary;
   }
 }
+
+.wide-image:not(.row-full-width) {
+  img {
+    max-width: 100%;
+  }
+}
+
+@media (min-width: #{map-get($grid-breakpoints, md)}) {
+  .it-page-sections-container {
+    .wide-image:not(.row-full-width) {
+      margin-right: -2em;
+      margin-left: -2em;
+    }
+  }
+}


### PR DESCRIPTION
Aggiunta la possibilità di definire in configurazione, nell'oggetto 
```
const view= {...
  italiaThemeViewsConfig: {
    imagePosition: 'afterHeader', //values: afterHeader, documentBody
  },
}
```
la posizione dell'immagine nelle viste dei contentType. Il default è 'afterHeader' come previsto da agid, nel proprio sito si può decidere di mostrarla nel documentBody, prima di tutte le altre informazioni.