### PR TITLE
dev: added siteConfig for site specific properties

### DIFF
--- a/src/components/ItaliaTheme/Footer/FooterInfos.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterInfos.jsx
@@ -17,6 +17,7 @@ import {
   LinkList,
   LinkListItem,
 } from 'design-react-kit/dist/design-react-kit';
+import { siteConfig } from '~/config';
 
 const messages = defineMessages({
   goToPage: {
@@ -108,9 +109,9 @@ const FooterInfos = () => {
           </Link>
         </h4>
         <p>
-          <strong>Nome del Comune</strong>
+          <strong>{siteConfig.siteTitle}</strong>
           <br />
-          Via Roma 0 - 00000 Lorem Ipsum Codice fiscale / P. IVA: 000000000
+          {siteConfig.footerInfos}
         </p>
 
         <LinkList className="footer-list clearfix">
@@ -199,32 +200,27 @@ const FooterInfos = () => {
           <Link to="#">{intl.formatMessage(messages.followUs)}</Link>
         </h4>
         <ul className="list-inline text-left social">
-          <li className="list-inline-item">
-            <Link className="p-2 text-white" to="#" target="_blank">
-              <Icon
-                icon="it-facebook"
-                color="white"
-                className="align-top"
-                padding={false}
-                size="sm"
-              />
+          {siteConfig.socialSettings?.map((social, idx) => (
+            <li className="list-inline-item" key={idx}>
+              <a
+                className="p-2 text-white"
+                href={social.url}
+                title={social.title}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Icon
+                  icon={social.icon}
+                  color="white"
+                  className="align-top"
+                  padding={false}
+                  size="sm"
+                />
 
-              <span className="sr-only">Facebook</span>
-            </Link>
-          </li>
-          <li className="list-inline-item">
-            <Link className="p-2 text-white" to="#" target="_blank">
-              <Icon
-                icon="it-twitter"
-                color="white"
-                className="align-top"
-                padding={false}
-                size="sm"
-              />
-
-              <span className="sr-only">Twitter</span>
-            </Link>
-          </li>
+                <span className="sr-only">{social.title}</span>
+              </a>
+            </li>
+          ))}
         </ul>
       </Col>
     </Row>

--- a/src/components/ItaliaTheme/Footer/FooterInfos.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterInfos.jsx
@@ -109,9 +109,9 @@ const FooterInfos = () => {
           </Link>
         </h4>
         <p>
-          <strong>{siteConfig.siteTitle}</strong>
+          <strong>{siteConfig.properties.siteTitle}</strong>
           <br />
-          {siteConfig.footerInfos}
+          {siteConfig.properties.footerInfos}
         </p>
 
         <LinkList className="footer-list clearfix">

--- a/src/components/ItaliaTheme/Footer/FooterMain.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterMain.jsx
@@ -13,6 +13,7 @@ import {
 } from 'design-react-kit/dist/design-react-kit';
 
 import { FooterNavigation, FooterInfos } from '@italia/components/ItaliaTheme/';
+import { siteConfig } from '~/config';
 
 /**
  * FooterMain component class.
@@ -30,9 +31,9 @@ const FooterMain = () => {
                 <Link to="/">
                   <Icon color="" icon="it-pa" padding={false} size="" />
                   <div className="it-brand-text">
-                    <h2 className="no_toc">Nome del Comune</h2>
+                    <h2 className="no_toc">{siteConfig.siteTitle}</h2>
                     <h3 className="no_toc d-none d-md-block">
-                      Uno dei tanti Comuni d'Italia
+                      {siteConfig.siteSubtitle}
                     </h3>
                   </div>
                 </Link>

--- a/src/components/ItaliaTheme/Footer/FooterMain.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterMain.jsx
@@ -31,9 +31,11 @@ const FooterMain = () => {
                 <Link to="/">
                   <Icon color="" icon="it-pa" padding={false} size="" />
                   <div className="it-brand-text">
-                    <h2 className="no_toc">{siteConfig.siteTitle}</h2>
+                    <h2 className="no_toc">
+                      {siteConfig.properties.siteTitle}
+                    </h2>
                     <h3 className="no_toc d-none d-md-block">
-                      {siteConfig.siteSubtitle}
+                      {siteConfig.properties.siteSubtitle}
                     </h3>
                   </div>
                 </Link>

--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -15,6 +15,7 @@ import {
 } from 'design-react-kit/dist/design-react-kit';
 
 import { SearchModal } from '@italia/components/ItaliaTheme';
+import { siteConfig } from '~/config';
 
 const messages = defineMessages({
   followUs: {
@@ -38,9 +39,9 @@ const HeaderCenter = () => {
           <Link to="/">
             <Icon color="" icon="it-pa" padding={false} size="" />
             <div className="it-brand-text">
-              <h2 className="no_toc">Nome del Comune</h2>
+              <h2 className="no_toc">{siteConfig.siteTitle}</h2>
               <h3 className="no_toc d-none d-md-block">
-                Uno dei tanti Comuni d'Italia
+                {siteConfig.siteSubtitle}
               </h3>
             </div>
           </Link>
@@ -48,36 +49,18 @@ const HeaderCenter = () => {
         <HeaderRightZone>
           <HeaderSocialsZone label={intl.formatMessage(messages.followUs)}>
             <ul>
-              <li>
-                <a
-                  title="Facebook"
-                  href="https://facebook.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Icon color="" icon="it-facebook" padding={false} size="" />
-                </a>
-              </li>
-              <li>
-                <a
-                  title="Github"
-                  href="https://github.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Icon color="" icon="it-github" padding={false} size="" />
-                </a>
-              </li>
-              <li>
-                <a
-                  title="Twitter"
-                  href="https://twitter.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Icon color="" icon="it-twitter" padding={false} size="" />
-                </a>
-              </li>
+              {siteConfig.socialSettings?.map((social, idx) => (
+                <li key={idx}>
+                  <a
+                    title={social.title}
+                    href={social.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Icon color="" icon={social.icon} padding={false} size="" />
+                  </a>
+                </li>
+              ))}
             </ul>
           </HeaderSocialsZone>
           <div className="it-search-wrapper">

--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -41,7 +41,7 @@ const HeaderCenter = () => {
             <div className="it-brand-text">
               <h2 className="no_toc">{siteConfig.siteTitle}</h2>
               <h3 className="no_toc d-none d-md-block">
-                {siteConfig.siteSubtitle}
+                {siteConfig.properties.siteSubtitle}
               </h3>
             </div>
           </Link>

--- a/src/components/ItaliaTheme/Header/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim.jsx
@@ -17,6 +17,7 @@ import {
 } from 'design-react-kit/dist/design-react-kit';
 
 import { LanguageSelector } from '@italia/components/ItaliaTheme';
+import { siteConfig } from '~/config';
 
 const messages = defineMessages({
   arLogin: {
@@ -31,8 +32,13 @@ const HeaderSlim = () => {
   return (
     <Header small={false} theme="" type="slim">
       <HeaderContent>
-        <HeaderBrand responsive tag={Link} to="/">
-          Nome della Regione
+        <HeaderBrand
+          responsive
+          href={siteConfig.parentSiteURL}
+          target="_blank"
+          rel="noopener noreferer"
+        >
+          {siteConfig.parentSiteTitle}
         </HeaderBrand>
         <HeaderRightZone>
           <LanguageSelector />

--- a/src/components/ItaliaTheme/Header/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim.jsx
@@ -34,11 +34,11 @@ const HeaderSlim = () => {
       <HeaderContent>
         <HeaderBrand
           responsive
-          href={siteConfig.parentSiteURL}
+          href={siteConfig.properties.parentSiteURL}
           target="_blank"
           rel="noopener noreferer"
         >
-          {siteConfig.parentSiteTitle}
+          {siteConfig.properties.parentSiteTitle}
         </HeaderBrand>
         <HeaderRightZone>
           <LanguageSelector />

--- a/src/components/ItaliaTheme/View/Commons/ContentImage.jsx
+++ b/src/components/ItaliaTheme/View/Commons/ContentImage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { views } from '~/config';
+import { siteConfig } from '~/config';
 import { WideImage } from '@italia/components/ItaliaTheme/View';
 /**
  * ContentImage view component class.
@@ -11,14 +11,16 @@ import { WideImage } from '@italia/components/ItaliaTheme/View';
 const ContentImage = ({ content, position }) => {
   const view =
     (content?.image || content?.image_caption) &&
-    views.italiaThemeViewsConfig.imagePosition === position;
+    siteConfig.italiaThemeViewsConfig.imagePosition === position;
 
   return view ? (
     <WideImage
       title={content?.title}
       image={content?.image}
       caption={content?.image_caption}
-      fullWidth={views.italiaThemeViewsConfig.imagePosition === 'afterHeader'}
+      fullWidth={
+        siteConfig.italiaThemeViewsConfig.imagePosition === 'afterHeader'
+      }
     />
   ) : null;
 };

--- a/src/config.js
+++ b/src/config.js
@@ -268,9 +268,37 @@ export const views = {
     Event: EventoView,
     'Pagina Argomento': PaginaArgomentoView,
   },
+};
+
+export const siteConfig = {
   italiaThemeViewsConfig: {
-    imagePosition: 'afterHeader', //values: afterHeader, documentBody
+    imagePosition: 'afterHeader', // possible values: afterHeader, documentBody
   },
+  properties: {
+    siteTitle: 'Nome del Comune',
+    siteSubtitle: "Uno dei tanti Comuni d'Italia",
+    parentSiteTitle: 'Nome della Regione',
+    parentSiteURL: 'https://www.governo.it',
+    footerInfos:
+      'Via Roma 0 - 00000 Lorem Ipsum Codice fiscale / P. IVA: 000000000',
+  },
+  socialSettings: [
+    {
+      title: 'Facebook',
+      url: 'https://facebook.com',
+      icon: 'it-facebook',
+    },
+    {
+      title: 'GitHub',
+      url: 'https://github.com',
+      icon: 'it-github',
+    },
+    {
+      title: 'Twitter',
+      url: 'https://twitter.com',
+      icon: 'it-twitter',
+    },
+  ],
 };
 
 export const widgets = {


### PR DESCRIPTION
Ora abbiamo un oggetto di configurazione per dover customizzare il meno possibile nei progetti figli

```js
export const siteConfig = {
  italiaThemeViewsConfig: {
    imagePosition: 'afterHeader', // possible values: afterHeader, documentBody
  },
  properties: {
    siteTitle: 'Nome del Comune',
    siteSubtitle: "Uno dei tanti Comuni d'Italia",
    parentSiteTitle: 'Nome della Regione',
    parentSiteURL: 'https://www.governo.it',
    footerInfos:
      'Via Roma 0 - 00000 Lorem Ipsum Codice fiscale / P. IVA: 000000000',
  },
  socialSettings: [
    {
      title: 'Facebook',
      url: 'https://facebook.com',
      icon: 'it-facebook',
    },
    {
      title: 'GitHub',
      url: 'https://github.com',
      icon: 'it-github',
    },
    {
      title: 'Twitter',
      url: 'https://twitter.com',
      icon: 'it-twitter',
    },
  ],
};
```