### PR TITLE
Us 10947 fix listing dates

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -22,7 +22,8 @@ import {
   ChipLabel,
 } from 'design-react-kit/dist/design-react-kit';
 import { getCalendarDate } from '@italia/helpers';
-import { CardCalendar } from './Commons/CardCalendar'
+
+import { getItemIcon, CardCalendar } from '@italia/components/ItaliaTheme';
 
 const CardWithImageTemplate = ({
   items,
@@ -38,7 +39,7 @@ const CardWithImageTemplate = ({
     <div
       className={cx('card-with-image-template', { 'public-ui': isEditMode })}
     >
-      <div className='full-width'>
+      <div className="full-width">
         <Container className="px-4">
           {title && (
             <Row>
@@ -51,15 +52,8 @@ const CardWithImageTemplate = ({
           )}
           <Row className="items">
             {items.map((item, index) => {
-              let date = null;
-              switch (item['@type']) {
-                case 'News Item':
-                  date = item.effective && moment(item.effective).format('ll');
-                  break;
-                default:
-                  date = null;
-              }
-
+              const icon = getItemIcon(item);
+              const date = getCalendarDate(item);
               return (
                 <Col md="4" key={item['@id']} className="col-item">
                   <Card
@@ -86,24 +80,23 @@ const CardWithImageTemplate = ({
                               />
                             </figure>
                           </ConditionalLink>
-                          { 
-                            (item['@type'] == 'Event') && 
-                              <CardCalendar 
-                                start={item.start}
-                                end={item.end}
-                              /> 
-                          }
+                          {item['@type'] === 'Event' && (
+                            <CardCalendar start={item.start} end={item.end} />
+                          )}
                         </div>
                       </div>
                     )}
                     <CardBody>
-                      <CardCategory date={getCalendarDate(item)}>
-                        <Icon
-                          className='icon mr-2'
-                          color="primary"
-                          icon={getIcon(item['@type'])}
-                          padding={false}
-                        />
+                      <CardCategory iconName={!date ? icon : null} date={date}>
+                        {date && (
+                          <Icon
+                            className="icon mr-2"
+                            color="primary"
+                            icon={getIcon(item['@type'])}
+                            padding={false}
+                          />
+                        )}{' '}
+                        {/*questo perchè CardCategory mostra o l'icona o la data */}
                         {item?.design_italia_meta_type}
                       </CardCategory>
                       <CardTitle tag="h4">
@@ -111,29 +104,27 @@ const CardWithImageTemplate = ({
                           {item.title || item.id}
                         </Link>
                       </CardTitle>
-                      {item.description && <CardText>{item.description}</CardText>}
-                      {
-                        item.tassonomia_argomenti?.map((argument, index) => (
-                          <Link
-                            to={flattenToAppURL(argument['@id'])}
-                            key={index}
-                            title={argument.title}
-                            className="text-decoration-none"
+                      {item.description && (
+                        <CardText>{item.description}</CardText>
+                      )}
+                      {item.tassonomia_argomenti?.map((argument, index) => (
+                        <Link
+                          to={flattenToAppURL(argument['@id'])}
+                          key={index}
+                          title={argument.title}
+                          className="text-decoration-none"
+                        >
+                          <Chip
+                            color="primary"
+                            disabled={false}
+                            simple
+                            tag="div"
+                            className="mr-2"
                           >
-                            <Chip
-                              color="primary"
-                              disabled={false}
-                              simple
-                              tag="div"
-                              className="mr-2"
-                            >
-                              <ChipLabel tag="span">
-                                {argument.title}
-                              </ChipLabel>
-                            </Chip>
-                          </Link>
-                        ))
-                      } 
+                            <ChipLabel tag="span">{argument.title}</ChipLabel>
+                          </Chip>
+                        </Link>
+                      ))}
                     </CardBody>
                   </Card>
                 </Col>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -21,7 +21,7 @@ import {
   Chip,
   ChipLabel,
 } from 'design-react-kit/dist/design-react-kit';
-import { getCalendarDate } from '@italia/helpers';
+import { getCalendarDate, getEventRecurrenceMore } from '@italia/helpers';
 
 import { getItemIcon, CardCalendar } from '@italia/components/ItaliaTheme';
 
@@ -54,6 +54,10 @@ const CardWithImageTemplate = ({
             {items.map((item, index) => {
               const icon = getItemIcon(item);
               const date = getCalendarDate(item);
+              const eventRecurrenceMore = getEventRecurrenceMore(
+                item,
+                isEditMode,
+              );
               return (
                 <Col md="4" key={item['@id']} className="col-item">
                   <Card
@@ -104,27 +108,42 @@ const CardWithImageTemplate = ({
                           {item.title || item.id}
                         </Link>
                       </CardTitle>
-                      {item.description && (
-                        <CardText>{item.description}</CardText>
+                      {(item.description ||
+                        item.tassonomia_argomenti.length > 0) && (
+                        <CardText>
+                          {item.description && (
+                            <div
+                              className={cx('', {
+                                'mb-3': item.tassonomia_argomenti.length > 0,
+                              })}
+                            >
+                              {item.description}
+                            </div>
+                          )}
+                          {item.tassonomia_argomenti?.map((argument, index) => (
+                            <Link
+                              to={flattenToAppURL(argument['@id'])}
+                              key={index}
+                              title={argument.title}
+                              className="text-decoration-none"
+                            >
+                              <Chip
+                                color="primary"
+                                disabled={false}
+                                simple
+                                tag="div"
+                                className="mr-2"
+                              >
+                                <ChipLabel tag="span">
+                                  {argument.title}
+                                </ChipLabel>
+                              </Chip>
+                            </Link>
+                          ))}
+                        </CardText>
                       )}
-                      {item.tassonomia_argomenti?.map((argument, index) => (
-                        <Link
-                          to={flattenToAppURL(argument['@id'])}
-                          key={index}
-                          title={argument.title}
-                          className="text-decoration-none"
-                        >
-                          <Chip
-                            color="primary"
-                            disabled={false}
-                            simple
-                            tag="div"
-                            className="mr-2"
-                          >
-                            <ChipLabel tag="span">{argument.title}</ChipLabel>
-                          </Chip>
-                        </Link>
-                      ))}
+
+                      {eventRecurrenceMore}
                     </CardBody>
                   </Card>
                 </Col>

--- a/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -17,7 +17,11 @@ import { ConditionalLink } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { Link } from 'react-router-dom';
 import cx from 'classnames';
-import { getIcon, getCalendarDate } from '@italia/helpers';
+import {
+  getIcon,
+  getCalendarDate,
+  getEventRecurrenceMore,
+} from '@italia/helpers';
 import { CardCalendar, getItemIcon } from '@italia/components/ItaliaTheme';
 
 const InEvidenceTemplate = ({
@@ -48,6 +52,10 @@ const InEvidenceTemplate = ({
             {items.map((item, index) => {
               const icon = getItemIcon(item);
               const date = getCalendarDate(item);
+              const eventRecurrenceMore = getEventRecurrenceMore(
+                item,
+                isEditMode,
+              );
               return (
                 <Card
                   key={index}
@@ -96,27 +104,39 @@ const InEvidenceTemplate = ({
                         {item.title || item.id}
                       </Link>
                     </CardTitle>
-                    {item.description && (
-                      <CardText>{item.description}</CardText>
+                    {(item.description ||
+                      item.tassonomia_argomenti?.length > 0) && (
+                      <CardText>
+                        {item.description && (
+                          <div
+                            className={cx('', {
+                              'mb-3': item.tassonomia_argomenti.length > 0,
+                            })}
+                          >
+                            {item.description}
+                          </div>
+                        )}
+                        {item.tassonomia_argomenti?.map((argument, index) => (
+                          <Link
+                            to={flattenToAppURL(argument['@id'])}
+                            key={index}
+                            title={argument.title}
+                            className="text-decoration-none"
+                          >
+                            <Chip
+                              color="primary"
+                              disabled={false}
+                              simple
+                              tag="div"
+                              className="mr-2"
+                            >
+                              <ChipLabel tag="span">{argument.title}</ChipLabel>
+                            </Chip>
+                          </Link>
+                        ))}
+                      </CardText>
                     )}
-                    {item.tassonomia_argomenti?.map((argument, index) => (
-                      <Link
-                        to={flattenToAppURL(argument['@id'])}
-                        key={index}
-                        title={argument.title}
-                        className="text-decoration-none"
-                      >
-                        <Chip
-                          color="primary"
-                          disabled={false}
-                          simple
-                          tag="div"
-                          className="mr-2"
-                        >
-                          <ChipLabel tag="span">{argument.title}</ChipLabel>
-                        </Chip>
-                      </Link>
-                    ))}
+                    {eventRecurrenceMore}
                   </CardBody>
                 </Card>
               );

--- a/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -11,15 +11,14 @@ import {
   CardText,
   Chip,
   ChipLabel,
-  Icon
+  Icon,
 } from 'design-react-kit/dist/design-react-kit';
 import { ConditionalLink } from '@plone/volto/components';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { Link } from 'react-router-dom';
 import cx from 'classnames';
-import { getIcon } from '@italia/helpers';
-import { getCalendarDate } from '@italia/helpers';
-import { CardCalendar } from './Commons/CardCalendar'
+import { getIcon, getCalendarDate } from '@italia/helpers';
+import { CardCalendar, getItemIcon } from '@italia/components/ItaliaTheme';
 
 const InEvidenceTemplate = ({
   items,
@@ -34,7 +33,7 @@ const InEvidenceTemplate = ({
         'public-ui': isEditMode,
       })}
     >
-      <div className='full-width'>
+      <div className="full-width">
         <Container className="px-4">
           {title && (
             <Row>
@@ -46,58 +45,61 @@ const InEvidenceTemplate = ({
             </Row>
           )}
           <div className="in-evidence-cards-wrapper mb-5">
-            {items.map((item, index) => (
-              <Card
-                key={index}
-                className={cx('listing-item card-bg', {
-                  'card-img': index === 0 && item.image,
-                })}
-              >
-                {index === 0 && item.image && (
-                  <div className="img-responsive-wrapper">
-                    <div className="img-responsive">
-                      <Link
-                        to={flattenToAppURL(item['@id'])}
-                        className="img-link"
-                      >
-                        <figure className="img-wrapper">
-                          <img
-                            className="listing-image"
-                            src={flattenToAppURL(
-                              item.image.scales.preview.download,
-                            )}
-                            alt={item.title}
-                          />
-                        </figure>
-                      </Link>
-                      { 
-                        (item['@type'] == 'Event') &&
-                          <CardCalendar 
-                            start={item.start}
-                            end={item.end}
-                          /> 
-                      }
+            {items.map((item, index) => {
+              const icon = getItemIcon(item);
+              const date = getCalendarDate(item);
+              return (
+                <Card
+                  key={index}
+                  className={cx('listing-item card-bg', {
+                    'card-img': index === 0 && item.image,
+                  })}
+                >
+                  {index === 0 && item.image && (
+                    <div className="img-responsive-wrapper">
+                      <div className="img-responsive">
+                        <Link
+                          to={flattenToAppURL(item['@id'])}
+                          className="img-link"
+                        >
+                          <figure className="img-wrapper">
+                            <img
+                              className="listing-image"
+                              src={flattenToAppURL(
+                                item.image.scales.preview.download,
+                              )}
+                              alt={item.title}
+                            />
+                          </figure>
+                        </Link>
+                        {item['@type'] == 'Event' && (
+                          <CardCalendar start={item.start} end={item.end} />
+                        )}
+                      </div>
                     </div>
-                  </div>
-                )}
-                <CardBody>
-                  <CardCategory date={getCalendarDate(item)}>
-                    <Icon
-                      className='icon'
-                      color="primary"
-                      icon={getIcon(item['@type'])}
-                      padding={false}
-                    />
-                    {item?.design_italia_meta_type}
-                  </CardCategory>
-                  <CardTitle tag="h4">
-                    <Link to={flattenToAppURL(item['@id'])}>
-                      {item.title || item.id}
-                    </Link>
-                  </CardTitle>
-                  {item.description && <CardText>{item.description}</CardText>}
-                  {
-                    item.tassonomia_argomenti?.map((argument, index) => (
+                  )}
+                  <CardBody>
+                    <CardCategory iconName={!date ? icon : null} date={date}>
+                      {/*questo perchè CardCategory mostra o l'icona o la data */}
+                      {date && (
+                        <Icon
+                          className="icon"
+                          color="primary"
+                          icon={getIcon(item['@type'])}
+                          padding={false}
+                        />
+                      )}{' '}
+                      {item?.design_italia_meta_type}
+                    </CardCategory>
+                    <CardTitle tag="h4">
+                      <Link to={flattenToAppURL(item['@id'])}>
+                        {item.title || item.id}
+                      </Link>
+                    </CardTitle>
+                    {item.description && (
+                      <CardText>{item.description}</CardText>
+                    )}
+                    {item.tassonomia_argomenti?.map((argument, index) => (
                       <Link
                         to={flattenToAppURL(argument['@id'])}
                         key={index}
@@ -111,16 +113,14 @@ const InEvidenceTemplate = ({
                           tag="div"
                           className="mr-2"
                         >
-                          <ChipLabel tag="span">
-                            {argument.title}
-                          </ChipLabel>
+                          <ChipLabel tag="span">{argument.title}</ChipLabel>
                         </Chip>
                       </Link>
-                    ))
-                  } 
-                </CardBody>
-              </Card>
-            ))}
+                    ))}
+                  </CardBody>
+                </Card>
+              );
+            })}
           </div>
           {linkMore?.href && (
             <div className="link-more">

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -20,6 +20,7 @@ import {
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { Link } from 'react-router-dom';
 import { getItemIcon } from '@italia/components/ItaliaTheme';
+import { getCalendarDate } from '@italia/helpers';
 
 const messages = defineMessages({
   view_all: {
@@ -51,7 +52,7 @@ const RibbonCardTemplate = ({
         'public-ui': isEditMode,
       })}
     >
-      <div className='full-width'>
+      <div className="full-width">
         <Container className="px-4">
           {title && (
             <Row>
@@ -68,6 +69,7 @@ const RibbonCardTemplate = ({
                 !show_only_first_ribbon ||
                 (show_only_first_ribbon && index === 0);
               const icon = getItemIcon(item);
+              const date = getCalendarDate(item);
 
               return (
                 <Col lg={4} sm={12}>
@@ -93,6 +95,7 @@ const RibbonCardTemplate = ({
                       tag="div"
                       className={cx('', { 'mt-5': !showRibbon })}
                     >
+                      {date && <div className="dates">{date}</div>}
                       <CardTitle tag="h5">
                         <Link
                           to={!isEditMode ? flattenToAppURL(item['@id']) : '#'}

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -20,7 +20,7 @@ import {
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { Link } from 'react-router-dom';
 import { getItemIcon } from '@italia/components/ItaliaTheme';
-import { getCalendarDate } from '@italia/helpers';
+import { getCalendarDate, getEventRecurrenceMore } from '@italia/helpers';
 
 const messages = defineMessages({
   view_all: {
@@ -70,7 +70,10 @@ const RibbonCardTemplate = ({
                 (show_only_first_ribbon && index === 0);
               const icon = getItemIcon(item);
               const date = getCalendarDate(item);
-
+              const eventRecurrenceMore = getEventRecurrenceMore(
+                item,
+                isEditMode,
+              );
               return (
                 <Col lg={4} sm={12}>
                   <Card
@@ -104,6 +107,7 @@ const RibbonCardTemplate = ({
                         </Link>
                       </CardTitle>
                       <CardText>{item.description}</CardText>
+                      {eventRecurrenceMore}
                       {show_detail_link && (
                         <CardReadMore
                           iconName="it-arrow-right"

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -21,6 +21,7 @@ import { Link } from 'react-router-dom';
 import cx from 'classnames';
 
 import { getItemIcon } from '@italia/components/ItaliaTheme';
+import { getCalendarDate } from '@italia/helpers';
 
 const messages = defineMessages({
   view_all: {
@@ -74,10 +75,7 @@ const SimpleCardTemplateDefault = ({
         {items.map((item, index) => {
           const icon = getItemIcon(item);
           const itemTitle = item.title || item.id;
-          const date =
-            item['@type'] === 'News Item' && item.effective
-              ? moment(item.effective).format('ll')
-              : null;
+          const date = getCalendarDate(item);
 
           return (
             <Card

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -21,7 +21,7 @@ import { Link } from 'react-router-dom';
 import cx from 'classnames';
 
 import { getItemIcon } from '@italia/components/ItaliaTheme';
-import { getCalendarDate } from '@italia/helpers';
+import { getCalendarDate, getEventRecurrenceMore } from '@italia/helpers';
 
 const messages = defineMessages({
   view_all: {
@@ -53,10 +53,10 @@ const SimpleCardTemplateDefault = ({
         className = item.tipologia_notizia?.token
           .toLowerCase()
           .replace(' ', '_');
-
         break;
       default:
-        className = className;
+        className = null;
+        break;
     }
     return className;
   };
@@ -76,6 +76,7 @@ const SimpleCardTemplateDefault = ({
           const icon = getItemIcon(item);
           const itemTitle = item.title || item.id;
           const date = getCalendarDate(item);
+          const eventRecurrenceMore = getEventRecurrenceMore(item, isEditMode);
 
           return (
             <Card
@@ -105,9 +106,11 @@ const SimpleCardTemplateDefault = ({
                   </Link>
                 </CardTitle>
                 {show_description && item.description && (
-                  <CardText>{item.description}</CardText>
+                  <CardText className={cx('', { 'mb-5': eventRecurrenceMore })}>
+                    {item.description}
+                  </CardText>
                 )}
-
+                {eventRecurrenceMore}
                 {show_detail_link && (
                   <CardReadMore
                     iconName="it-arrow-right"

--- a/src/components/ItaliaTheme/View/Commons/Dates.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Dates.jsx
@@ -48,7 +48,7 @@ const Dates = ({ content, show_image }) => {
       forceset: true,
     });
     recurrenceText = rruleSet.rrules()[0]?.toText(
-      t => {
+      (t) => {
         return RRULE_LANGUAGE.strings[t];
       },
       RRULE_LANGUAGE,
@@ -118,7 +118,7 @@ const Dates = ({ content, show_image }) => {
       {rruleSet?.rdates().length > 0 && (
         <div className="mt-4">
           <h5>{intl.formatMessage(messages.additional_dates)}</h5>
-          {rruleSet.rdates().map(additionalDate => (
+          {rruleSet.rdates().map((additionalDate) => (
             <div className="text-serif">
               {moment(additionalDate).format('dddd DD MMMM YYYY')}
             </div>
@@ -128,7 +128,7 @@ const Dates = ({ content, show_image }) => {
       {rruleSet?.exdates().length > 0 && (
         <div className="mt-4">
           <h5>{intl.formatMessage(messages.excluded_dates)}</h5>
-          {rruleSet.exdates().map(exDate => (
+          {rruleSet.exdates().map((exDate) => (
             <div className="text-serif">
               {moment(exDate).format('dddd DD MMMM YYYY')}
             </div>

--- a/src/components/ItaliaTheme/View/Commons/GenericCard.jsx
+++ b/src/components/ItaliaTheme/View/Commons/GenericCard.jsx
@@ -20,7 +20,6 @@ const GenericCard = ({
   show_icon,
   showDescription = true,
   showInfos = false,
-  showInfosFor = null,
   children,
 }) => {
   let item_fo = null;
@@ -31,18 +30,17 @@ const GenericCard = ({
 
   const infos = (
     <>
-      {showInfos &&
-        (!showInfosFor || showInfosFor.indexOf(item['@type']) >= 0) && (
-          <CardCategory date={getCalendarDate(item)}>
-            <Icon
-              className="icon"
-              color="primary"
-              icon={getIcon(item['@type'])}
-              padding={false}
-            />
-            {item?.design_italia_meta_type}
-          </CardCategory>
-        )}
+      {showInfos && (
+        <CardCategory date={getCalendarDate(item)}>
+          <Icon
+            className="icon"
+            color="primary"
+            icon={getIcon(item['@type'])}
+            padding={false}
+          />
+          {item?.design_italia_meta_type}
+        </CardCategory>
+      )}
     </>
   );
 

--- a/src/components/ItaliaTheme/View/Commons/RelatedItems.jsx
+++ b/src/components/ItaliaTheme/View/Commons/RelatedItems.jsx
@@ -152,7 +152,6 @@ const RelatedItems = ({
                               showimage={true}
                               image_field="image"
                               showInfos={true}
-                              showInfosFor={['News Item', 'Event']}
                             />
                           </div>
                         </Col>

--- a/src/components/ItaliaTheme/index.js
+++ b/src/components/ItaliaTheme/index.js
@@ -68,6 +68,7 @@ export LinkToWidget from '@italia/components/ItaliaTheme/manage/Widgets/LinkToWi
 export IconWidget from '@italia/components/ItaliaTheme/manage/Widgets/IconWidget';
 //common
 export getItemIcon from '@italia/components/ItaliaTheme/common';
+export CardCalendar from '@italia/components/ItaliaTheme/Blocks/Listing/Commons/CardCalendar';
 
 export Logo from '@italia/components/ItaliaTheme/Logo/Logo';
 export LogoFooter from '@italia/components/ItaliaTheme/LogoFooter/LogoFooter';

--- a/src/customizations/components/theme/View/EventDatesInfo.jsx
+++ b/src/customizations/components/theme/View/EventDatesInfo.jsx
@@ -5,7 +5,14 @@ import moment from 'moment';
 import cx from 'classnames';
 import { RRule, rrulestr } from 'rrule';
 
-export const datesForDisplay = (start, end, start_date_format, end_date_format, start_time_format, end_time_format) => {
+export const datesForDisplay = (
+  start,
+  end,
+  start_date_format,
+  end_date_format,
+  start_time_format,
+  end_time_format,
+) => {
   const mStart = moment(start);
   const mEnd = moment(end);
   if (!mStart.isValid() || !mEnd.isValid()) {
@@ -13,8 +20,8 @@ export const datesForDisplay = (start, end, start_date_format, end_date_format, 
   }
   const sameDay = mStart.isSame(mEnd, 'day');
   const sameTime = mStart.isSame(mEnd, 'minute');
-  const sameMonth =  mStart.isSame(mEnd, 'month');
-  const sameYear =  mStart.isSame(mEnd, 'year');
+  const sameMonth = mStart.isSame(mEnd, 'month');
+  const sameYear = mStart.isSame(mEnd, 'year');
 
   return {
     sameDay,
@@ -28,9 +35,27 @@ export const datesForDisplay = (start, end, start_date_format, end_date_format, 
   };
 };
 
-export const When = ({ start, end, start_date_format = 'll' , end_date_format = 'll', start_time_format = 'LT', end_time_format = 'LT',
-                       whole_day, open_end, start_label, end_label, show_time = true }) => {
-  const datesInfo = datesForDisplay(start, end, start_date_format , end_date_format, start_time_format, end_time_format);
+export const When = ({
+  start,
+  end,
+  start_date_format = 'll',
+  end_date_format = 'll',
+  start_time_format = 'LT',
+  end_time_format = 'LT',
+  whole_day,
+  open_end,
+  start_label,
+  end_label,
+  show_time = true,
+}) => {
+  const datesInfo = datesForDisplay(
+    start,
+    end,
+    start_date_format,
+    end_date_format,
+    start_time_format,
+    end_time_format,
+  );
 
   if (!datesInfo) {
     console.warn('EventWhen: Received invalid start or end date.');
@@ -39,113 +64,121 @@ export const When = ({ start, end, start_date_format = 'll' , end_date_format = 
 
   const getDate = () => {
     // Same dates
-    if(datesInfo.sameDay && datesInfo.sameMonth && datesInfo.sameYear) {
-      return <>
-        {whole_day && (
-          <span className="start-date">{datesInfo.startDate}</span>
-        )}
-        {open_end && !whole_day && (
-          <>
+    if (datesInfo.sameDay && datesInfo.sameMonth && datesInfo.sameYear) {
+      return (
+        <>
+          {whole_day && (
             <span className="start-date">{datesInfo.startDate}</span>
-            {show_time && (
-              <>
-                &nbsp;{start_label || 'from'}&nbsp;
-                <span className="start-time">{datesInfo.startTime}</span>
-              </>
-            )}
-          </>
-        )}
-        {!(whole_day || open_end) && (
-          <>
-            <span className="start-date">{datesInfo.startDate}</span>
-            {show_time && (
-              <>
-               <span> </span>
-                <span className="start-time">{datesInfo.startTime}</span>
-                &nbsp;-&nbsp;
-                <span className="end-time">{datesInfo.endTime}</span>
-              </>
-            )}
-          </>
-        )}
-      </>
-    // Same month and year
-    } else if(datesInfo.sameMonth && datesInfo.sameYear) {
-      return <>
-        &nbsp;{start_label || 'from'}&nbsp;
-        <span className="start-date">{moment(start).format('DD')}</span>
-        {!whole_day && show_time && (
-          <>
-            <span> </span>
-            <span className="start-time">{datesInfo.startTime}</span>
-          </>
-        )}
-        &nbsp;{end_label || 'to'}&nbsp;
-        <span className="end-date">{moment(end).format('DD')}</span>
-        {!whole_day && show_time &&(
-          <>
-            <span> </span>
-            <span className="start-time">{datesInfo.endTime}</span>
-          </>
-        )}
-        <span> </span>
-        <span className="end-date">{moment(end).format('MMM')}</span>
-        <span> </span>
-        <span className="end-date">{moment(end).format('YYYY')}</span>
-      </>
-    // Same year
-    } else if(datesInfo.sameYear) {
-      return <>
-        &nbsp;{start_label || 'from'}&nbsp;
-        <span className="start-date">{moment(start).format('DD MMM')}</span>
-        {!whole_day && show_time && (
-          <>
-            <span> </span>
-            <span className="start-time">{datesInfo.startTime}</span>
-          </>
-        )}
-        &nbsp;{end_label || 'to'}&nbsp;
-        <span className="end-date">{moment(end).format('DD MMM')}</span>
-        {!whole_day && show_time &&(
-          <>
-            <span> </span>
-            <span className="start-time">{datesInfo.endTime}</span>
-          </>
-        )}
-        <span> </span>
-        <span className="end-date">{moment(end).format('YYYY')}</span>
-      </>
-    // different dates
-    } else {
-      return <>
-        <span className="start">
-          <span className="start-date">{datesInfo.startDate}</span>
+          )}
+          {open_end && !whole_day && (
+            <>
+              <span className="start-date">{datesInfo.startDate}</span>
+              {show_time && (
+                <>
+                  &nbsp;{start_label || 'from'}&nbsp;
+                  <span className="start-time">{datesInfo.startTime}</span>
+                </>
+              )}
+            </>
+          )}
+          {!(whole_day || open_end) && (
+            <>
+              <span className="start-date">{datesInfo.startDate}</span>
+              {show_time && (
+                <>
+                  <span> </span>
+                  <span className="start-time">{datesInfo.startTime}</span>
+                  &nbsp;-&nbsp;
+                  <span className="end-time">{datesInfo.endTime}</span>
+                </>
+              )}
+            </>
+          )}
+        </>
+      );
+      // Same month and year
+    } else if (datesInfo.sameMonth && datesInfo.sameYear) {
+      return (
+        <>
+          {start_label || 'from'}&nbsp;
+          <span className="start-date">{moment(start).format('DD')}</span>
           {!whole_day && show_time && (
             <>
-              {/* Plone has an optional word based on locale here */}
               <span> </span>
               <span className="start-time">{datesInfo.startTime}</span>
             </>
           )}
-        </span>
-        {!open_end && (
-          <>
-            &nbsp;{end_label || 'to'}&nbsp;
-            <span className="end">
-              <span className="end-date">{datesInfo.endDate}</span>
-              {!whole_day && show_time && (
-                <>
-                  {/* Plone has an optional word based on locale here */}
-                  <span> </span>
-                  <span className="end-time">{datesInfo.endTime}</span>
-                </>
-              )}
-            </span>
-          </>
-        )}
-      </>
+          &nbsp;{end_label || 'to'}&nbsp;
+          <span className="end-date">{moment(end).format('DD')}</span>
+          {!whole_day && show_time && (
+            <>
+              <span> </span>
+              <span className="start-time">{datesInfo.endTime}</span>
+            </>
+          )}
+          <span> </span>
+          <span className="end-date">{moment(end).format('MMM')}</span>
+          <span> </span>
+          <span className="end-date">{moment(end).format('YYYY')}</span>
+        </>
+      );
+      // Same year
+    } else if (datesInfo.sameYear) {
+      return (
+        <>
+          {start_label || 'from'}&nbsp;
+          <span className="start-date">{moment(start).format('DD MMM')}</span>
+          {!whole_day && show_time && (
+            <>
+              <span> </span>
+              <span className="start-time">{datesInfo.startTime}</span>
+            </>
+          )}
+          &nbsp;{end_label || 'to'}&nbsp;
+          <span className="end-date">{moment(end).format('DD MMM')}</span>
+          {!whole_day && show_time && (
+            <>
+              <span> </span>
+              <span className="start-time">{datesInfo.endTime}</span>
+            </>
+          )}
+          <span> </span>
+          <span className="end-date">{moment(end).format('YYYY')}</span>
+        </>
+      );
+      // different dates
+    } else {
+      return (
+        <>
+          <span className="start">
+            <span className="start-date">{datesInfo.startDate}</span>
+            {!whole_day && show_time && (
+              <>
+                {/* Plone has an optional word based on locale here */}
+                <span> </span>
+                <span className="start-time">{datesInfo.startTime}</span>
+              </>
+            )}
+          </span>
+          {!open_end && (
+            <>
+              &nbsp;{end_label || 'to'}&nbsp;
+              <span className="end">
+                <span className="end-date">{datesInfo.endDate}</span>
+                {!whole_day && show_time && (
+                  <>
+                    {/* Plone has an optional word based on locale here */}
+                    <span> </span>
+                    <span className="end-time">{datesInfo.endTime}</span>
+                  </>
+                )}
+              </span>
+            </>
+          )}
+        </>
+      );
     }
-  }
+  };
 
   return (
     <span
@@ -156,7 +189,7 @@ export const When = ({ start, end, start_date_format = 'll' , end_date_format = 
         'open-end': open_end,
       })}
     >
-      { getDate() }
+      {getDate()}
     </span>
   );
 };

--- a/src/helpers/ListingHelper.js
+++ b/src/helpers/ListingHelper.js
@@ -17,19 +17,28 @@ const messages = defineMessages({
 
 export const getCalendarDate = (item) => {
   const intl = useIntl();
+  const effective = item.effective && (
+    <span>{moment(item.effective).format('ll')}</span>
+  );
 
-  return item['@type'] === 'Event' ?
-            <When
-              start={item.start}
-              end={item.end}
-              whole_day={item.whole_day}
-              open_end={item.open_end}
-              start_label={intl.formatMessage(messages.from)}
-              end_label={intl.formatMessage(messages.to)}
-              start_date_format={'DD MMM YYYY'}
-              end_date_format={'DD MMM YYYY'}
-              show_time={false}
-            />
-          :
-            <span>{item.effective && moment(item.effective).format('ll')}</span>
-}
+  switch (item['@type']) {
+    case 'Event':
+      return (
+        <When
+          start={item.start}
+          end={item.end}
+          whole_day={item.whole_day}
+          open_end={item.open_end}
+          start_label={intl.formatMessage(messages.from)}
+          end_label={intl.formatMessage(messages.to)}
+          start_date_format={'DD MMM YYYY'}
+          end_date_format={'DD MMM YYYY'}
+          show_time={false}
+        />
+      );
+    case 'News Item':
+      return effective;
+    default:
+      return null;
+  }
+};

--- a/src/helpers/ListingHelper.js
+++ b/src/helpers/ListingHelper.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import { When } from '@plone/volto/components/theme/View/EventDatesInfo';
+import { Link } from 'react-router-dom';
 import { useIntl, defineMessages } from 'react-intl';
 import moment from 'moment';
 import 'moment/min/locales';
+import { flattenToAppURL } from '@plone/volto/helpers';
+import { When } from '@plone/volto/components/theme/View/EventDatesInfo';
 
 const messages = defineMessages({
   from: {
@@ -12,6 +14,10 @@ const messages = defineMessages({
   to: {
     id: 'to',
     defaultMessage: 'al',
+  },
+  event_recurrence_label: {
+    id: 'listing_event_recurrence_label',
+    defaultMessage: 'Questo evento ha più date: vedi tutte',
   },
 });
 
@@ -41,4 +47,21 @@ export const getCalendarDate = (item) => {
     default:
       return null;
   }
+};
+
+export const getEventRecurrenceMore = (item, isEditMode) => {
+  const intl = useIntl();
+  if (item['@type'] === 'Event') {
+    if (item.recurrence) {
+      return (
+        <Link
+          to={!isEditMode ? flattenToAppURL(item['@id']) : '#'}
+          className="event-recurrences-more"
+        >
+          {intl.formatMessage(messages.event_recurrence_label)}
+        </Link>
+      );
+    }
+  }
+  return null;
 };

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -7,5 +7,8 @@
 
 export { getIcon } from './iconHelper';
 export { defaultIconWidgetOptions } from '@italia/helpers/IconWidget/IconWidgetHelper';
-export { getCalendarDate } from '@italia/helpers/ListingHelper';
+export {
+  getCalendarDate,
+  getEventRecurrenceMore,
+} from '@italia/helpers/ListingHelper';
 export { contentFolderHasItems } from '@italia/helpers/contentHelper';

--- a/theme/ItaliaTheme/Blocks/_cardWithImageAndInEvidence.scss
+++ b/theme/ItaliaTheme/Blocks/_cardWithImageAndInEvidence.scss
@@ -49,6 +49,10 @@
         }
       }
     }
+
+    .event-recurrences-more {
+      bottom: $v-gap * 3;
+    }
   }
 
   .link-more {

--- a/theme/ItaliaTheme/Blocks/_listing.scss
+++ b/theme/ItaliaTheme/Blocks/_listing.scss
@@ -2,4 +2,15 @@
   .full-width {
     height: unset;
   }
+
+  .event-recurrences-more {
+    position: absolute;
+    bottom: $v-gap * 8;
+
+    display: flex;
+    align-items: center;
+    color: $card-link-color;
+    font-size: $card-category-size;
+    letter-spacing: $card-category-l-spacing;
+  }
 }

--- a/theme/ItaliaTheme/Blocks/_ribbonCardTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_ribbonCardTemplate.scss
@@ -1,5 +1,10 @@
 .ribbon-card-template {
   .card {
+    .dates {
+      font-size: 0.8em;
+      text-transform: uppercase;
+    }
+
     &.show_detail_link {
       .card-title {
         a {


### PR DESCRIPTION
mostrate le date dell'evento e della notizia nei vari template del listing.
Nel caso in cui si tratti di un evento con ricorrenza, d'accordo con Serena è stato aggiunto in fondo alla card il link al dettaglio dell'evento la cui label è 'Questo evento ha più date: vedi tutte'. In questo modo evitiamo di mostrare nella card una sbrodolata potenzialmente infinita di date della ricorrenza. 
Per esempio:
![Schermata 2020-11-06 alle 11 59 24](https://user-images.githubusercontent.com/51911425/98358846-988b2000-2027-11eb-899d-c717d9827a94.png)
