### PR TITLE
added customizable listing bg_color

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
+++ b/src/components/ItaliaTheme/Blocks/Calendar/Body.jsx
@@ -125,6 +125,7 @@ const Body = ({ data, inEditMode, path, onChangeBlock }) => {
       className={cx('full-width', {
         'bg-light py-5': data.show_block_bg,
         'public-ui': inEditMode,
+        [data.bg_color]: data.bg_color,
       })}
     >
       <Container>

--- a/src/components/ItaliaTheme/Blocks/Listing/Options/BgColor/BgColor.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Options/BgColor/BgColor.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ColorListWidget } from '@italia/components/ItaliaTheme';
+import { defineMessages, useIntl } from 'react-intl';
+import listing_bg_colors from '@italia/components/ItaliaTheme/Blocks/Listing/Options/BgColor/colors';
+
+const messages = defineMessages({
+  bg_color: {
+    id: 'block_bg_color',
+    defaultMessage: 'Colore di sfondo',
+  },
+});
+
+const BgColor = ({ data, block, onChangeBlock, required = false }) => {
+  const intl = useIntl();
+
+  return data.show_block_bg ? (
+    <ColorListWidget
+      id="bg_color"
+      title={intl.formatMessage(messages.bg_color)}
+      value={data.bg_color}
+      onChange={(name, value) => {
+        onChangeBlock(block, {
+          ...data,
+          [name]: value,
+        });
+      }}
+      intl={intl}
+      colors={listing_bg_colors}
+    />
+  ) : null;
+};
+
+BgColor.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any).isRequired,
+  block: PropTypes.string.isRequired,
+  onChangeBlock: PropTypes.func.isRequired,
+};
+
+export default BgColor;

--- a/src/components/ItaliaTheme/Blocks/Listing/Options/BgColor/colors.js
+++ b/src/components/ItaliaTheme/Blocks/Listing/Options/BgColor/colors.js
@@ -1,0 +1,7 @@
+/*example:
+const listing_bg_colors = [{name:'blue', label:'Blu'},{name:'light-blue', label:'Light blue'},{name:'sidebar-background', label:'Grey'}];
+//
+You also have to add styles for your color options in your theme.
+*/
+const listing_bg_colors = [];
+export default listing_bg_colors;

--- a/src/components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TextWidget, CheckboxWidget } from '@plone/volto/components';
 import { defineMessages, useIntl } from 'react-intl';
+import BgColor from '@italia/components/ItaliaTheme/Blocks/Listing/Options/BgColor/BgColor';
 
 const messages = defineMessages({
   title: {
@@ -14,7 +15,8 @@ const messages = defineMessages({
   },
 });
 
-const DefaultOptions = ({ data, block, onChangeBlock, required = false }) => {
+const DefaultOptions = (props) => {
+  const { data, block, onChangeBlock, required = false } = props;
   const intl = useIntl();
 
   return (
@@ -43,6 +45,8 @@ const DefaultOptions = ({ data, block, onChangeBlock, required = false }) => {
           });
         }}
       />
+
+      <BgColor {...props} />
     </>
   );
 };

--- a/src/components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions.jsx
@@ -6,6 +6,7 @@ import {
   TextWidget,
 } from '@plone/volto/components';
 import { defineMessages, useIntl } from 'react-intl';
+import DefaultOptions from '@italia/components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions';
 
 const messages = defineMessages({
   appearance: {
@@ -53,12 +54,8 @@ const messages = defineMessages({
 
 export const SimpleCardTemplateAppearance_COMPACT = 'compact';
 
-const SimpleCardTemplateOptions = ({
-  data,
-  block,
-  onChangeBlock,
-  required = false,
-}) => {
+const SimpleCardTemplateOptions = (props) => {
+  const { data, block, onChangeBlock, required = false } = props;
   const intl = useIntl();
   useEffect(() => {
     onChangeBlock(block, {
@@ -105,18 +102,7 @@ const SimpleCardTemplateOptions = ({
         ]}
       />
 
-      <TextWidget
-        id="title"
-        title={intl.formatMessage(messages.title)}
-        required={false}
-        value={data.title}
-        onChange={(name, value) => {
-          onChangeBlock(block, {
-            ...data,
-            [name]: value,
-          });
-        }}
-      />
+      <DefaultOptions {...props} />
 
       <CheckboxWidget
         id="show_icon"
@@ -129,7 +115,6 @@ const SimpleCardTemplateOptions = ({
           });
         }}
       />
-
       {data.appearance !== SimpleCardTemplateAppearance_COMPACT && (
         <CheckboxWidget
           id="show_section"
@@ -186,18 +171,6 @@ const SimpleCardTemplateOptions = ({
           )}
         </>
       )}
-
-      <CheckboxWidget
-        id="show_block_bg"
-        title={intl.formatMessage(messages.show_block_bg)}
-        value={data.show_block_bg ? data.show_block_bg : false}
-        onChange={(id, value) => {
-          onChangeBlock(block, {
-            ...data,
-            [id]: value,
-          });
-        }}
-      />
     </>
   );
 };

--- a/src/components/ItaliaTheme/index.js
+++ b/src/components/ItaliaTheme/index.js
@@ -54,6 +54,7 @@ export SectionIcon from '@italia/components/ItaliaTheme/Icons/SectionIcon';
 
 export CharCounterDescriptionWidget from '@italia/components/ItaliaTheme/manage/Widgets/CharCounterDescriptionWidget';
 export TextEditorWidget from '@italia/components/ItaliaTheme/manage/Widgets/TextEditorWidget';
+export ColorListWidget from '@italia/components/ItaliaTheme/manage/Widgets/ColorListWidget';
 export PageView from '@italia/components/ItaliaTheme/View/PageView/PageView';
 export VenueView from '@italia/components/ItaliaTheme/View/VenueView/VenueView';
 export NewsItemView from '@italia/components/ItaliaTheme/View/NewsItemView/NewsItemView';

--- a/src/components/ItaliaTheme/manage/Widgets/ColorListWidget.jsx
+++ b/src/components/ItaliaTheme/manage/Widgets/ColorListWidget.jsx
@@ -1,0 +1,101 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Form } from 'semantic-ui-react';
+import { Grid, Button } from 'semantic-ui-react';
+import { defineMessages, injectIntl } from 'react-intl';
+
+const messages = defineMessages({
+  Color: {
+    id: 'Color',
+    defaultMessage: 'Colore',
+  },
+});
+
+class ColorListWidget extends Component {
+  /**
+   * Property types.
+   * @property {Object} propTypes Property types.
+   * @static
+   */
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    required: PropTypes.bool,
+    value: PropTypes.string,
+    onChange: PropTypes.func,
+    colors: PropTypes.array,
+  };
+
+  /**
+   * Default properties.
+   * @property {Object} defaultProps Default properties.
+   * @static
+   */
+  static defaultProps = {
+    required: false,
+    value: null,
+    onChange: null,
+    colors: [],
+  };
+
+  /**
+   * Render method.
+   * @method render
+   * @returns {string} Markup for the component.
+   */
+  render() {
+    const {
+      id,
+      title,
+      required,
+      value,
+      onChange,
+      intl,
+      colors,
+      className,
+    } = this.props;
+
+    return colors.length > 0 ? (
+      <Form.Field
+        inline
+        required={required}
+        className={className}
+        id={'field-' + id}
+      >
+        <Grid>
+          <Grid.Row>
+            <Grid.Column width="4">
+              <div className="wrapper">
+                <label htmlFor={`field-${id}`}>
+                  {title ? title : intl.formatMessage(messages.Color)}
+                </label>
+              </div>
+            </Grid.Column>
+            <Grid.Column
+              width="8"
+              className="color-list-widget"
+              verticalAlign="middle"
+            >
+              {colors.map((color) => {
+                return (
+                  <Button
+                    key={id + color.name}
+                    className={color.name}
+                    onClick={(e) => {
+                      onChange(id, color.name);
+                    }}
+                    active={value === color.name}
+                    circular
+                    aria-label={color.label}
+                  />
+                );
+              })}
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Form.Field>
+    ) : null;
+  }
+}
+
+export default injectIntl(ColorListWidget);

--- a/src/customizations/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/customizations/components/manage/Blocks/Listing/ListingBody.jsx
@@ -88,10 +88,12 @@ const ListingBody = ({ data, properties, intl, path, isEditMode }) => {
     const block = properties.blocks[data.block];
     if (!block?.show_block_bg) return '';
 
+    let bg_color = data.bg_color ? `bg-${data.bg_color}` : '';
+
     if (block.template === 'gridGalleryTemplate') {
-      return 'section section-muted section-inset-shadow py-5';
+      return `section section-muted section-inset-shadow py-5 ${bg_color}`;
     } else {
-      return 'bg-light py-5';
+      return `bg-light py-5 ${bg_color}`;
     }
   };
 

--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -113,6 +113,17 @@ body.cms-ui {
     }
   }
 
+  .color-list-widget {
+    .button {
+      padding: 1rem;
+      border: 1px solid $gray-border;
+
+      &.active {
+        border: 2px solid $primary;
+      }
+    }
+  }
+
   // .DraftEditor-root {
   //   font-family: $font-family-serif;
   //   h1,


### PR DESCRIPTION
Ora si possono definire dei colori di sfondo aggiuntivi per i blocchi listing, oltre al grigio di base.
Per farlo, basta che ne vostro sito fate l'override di questo file src/components/ItaliaTheme/Blocks/Listing/Options/BgColor/colors.js
e definite il vostro elenco di colori.

Dovrete poi aggiungere gli stili nei vostri scss