### PR TITLE
Template filtri sezione us 14684

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { Segment } from 'semantic-ui-react';
 import {
   SelectWidget,
   CheckboxWidget,
   TextWidget,
+  ObjectBrowserWidget,
 } from '@plone/volto/components';
 import { defineMessages, useIntl } from 'react-intl';
 import DefaultOptions from '@italia/components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions';
@@ -54,6 +56,22 @@ const messages = defineMessages({
     id: 'Mostra lo sfondo del blocco',
     defaultMessage: 'Mostra lo sfondo del blocco',
   },
+  show_path_filters: {
+    id: 'Mostra i filtri per percorso',
+    defaultMessage: 'Mostra i filtri per percorso',
+  },
+  path_filter_label: {
+    id: 'Etichetta path filter',
+    defaultMessage: 'Etichetta',
+  },
+  path_filter_path: {
+    id: 'Percorso path filter',
+    defaultMessage: 'Percorso',
+  },
+  path_filter_filter: {
+    id: 'Path filter filtro',
+    defaultMessage: 'Filtro',
+  },
 });
 
 export const SimpleCardTemplateAppearance_COMPACT = 'compact';
@@ -79,6 +97,15 @@ const SimpleCardTemplateOptions = (props) => {
           : data.show_description,
     });
   }, [data.appearance]);
+
+  useEffect(() => {
+    if (!data.show_path_filters) {
+      onChangeBlock(block, {
+        ...data,
+        path_filters: {},
+      });
+    }
+  }, [data.show_path_filters]);
 
   return (
     <>
@@ -183,6 +210,73 @@ const SimpleCardTemplateOptions = (props) => {
                 });
               }}
             />
+          )}
+        </>
+      )}
+
+      {data.appearance !== SimpleCardTemplateAppearance_COMPACT && (
+        <>
+          <CheckboxWidget
+            id="show_path_filters"
+            title={intl.formatMessage(messages.show_path_filters)}
+            value={data.show_path_filters ? data.show_path_filters : false}
+            onChange={(id, value) => {
+              onChangeBlock(block, {
+                ...data,
+                [id]: value,
+              });
+            }}
+          />
+
+          {data.show_path_filters && (
+            <>
+              {[0, 1, 2, 3, 4].map((i) => (
+                <div className="path-filter-widget">
+                  <div className="filter-title">
+                    {intl.formatMessage(messages.path_filter_filter)} {i + 1}
+                  </div>
+                  <TextWidget
+                    id="label"
+                    title={intl.formatMessage(messages.path_filter_label)}
+                    required={false}
+                    value={data.path_filters?.[i]?.label}
+                    onChange={(name, value) => {
+                      let path_filters = data.path_filters
+                        ? JSON.parse(JSON.stringify(data.path_filters))
+                        : {};
+                      path_filters[i] = {
+                        ...(path_filters[i] || {}),
+                        [name]: value,
+                      };
+                      onChangeBlock(block, {
+                        ...data,
+                        path_filters: path_filters,
+                      });
+                    }}
+                  />
+                  <ObjectBrowserWidget
+                    id="path"
+                    title={intl.formatMessage(messages.path_filter_path)}
+                    required={false}
+                    mode={'link'}
+                    value={data.path_filters?.[i]?.path}
+                    onChange={(name, value) => {
+                      let path_filters = data.path_filters
+                        ? JSON.parse(JSON.stringify(data.path_filters))
+                        : {};
+                      path_filters[i] = {
+                        ...(path_filters[i] || {}),
+                        [name]: value,
+                      };
+                      onChangeBlock(block, {
+                        ...data,
+                        path_filters: path_filters,
+                      });
+                    }}
+                  />
+                </div>
+              ))}
+            </>
           )}
         </>
       )}

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';
 import moment from 'moment';
@@ -45,9 +45,13 @@ const SimpleCardTemplateDefault = ({
   title,
   show_block_bg,
   hide_dates,
+  path_filters,
+  show_path_filters,
+  addFilters,
 }) => {
   const intl = useIntl();
   moment.locale(intl.locale);
+  const [pathFilter, setPathFilter] = useState(null);
 
   const getItemClass = (item) => {
     let className = null;
@@ -64,13 +68,76 @@ const SimpleCardTemplateDefault = ({
     return className;
   };
 
+  const path_filters_buttons =
+    show_path_filters && path_filters
+      ? Object.keys(path_filters)
+          .map((k) => {
+            return {
+              label: path_filters[k].label,
+              path: path_filters[k].path[0],
+            };
+          })
+          .filter((f) => f.path)
+      : null;
+
+  const addPathFilter = (path) => {
+    let new_path = pathFilter === path ? null : path;
+    setPathFilter(new_path);
+    let filters = [];
+    if (new_path) {
+      filters = [
+        {
+          i: 'path',
+          o: 'plone.app.querystring.operation.string.absolutePath',
+          v: new_path,
+        },
+      ];
+    }
+    addFilters(filters);
+  };
+
   return (
     <div className="simple-card-default">
-      {title && (
-        <Row>
-          <Col>
-            <h2 className={cx('mb-4', { 'mt-5': !show_block_bg })}>{title}</h2>
-          </Col>
+      {(title || path_filters_buttons) && (
+        <Row
+          className={cx('template-header', {
+            'with-filters': path_filters_buttons,
+          })}
+        >
+          {title && (
+            <Col md={path_filters_buttons ? 6 : 12}>
+              <h2
+                className={cx('', {
+                  'mt-5': !show_block_bg,
+                  'mb-4': !path_filters_buttons,
+                })}
+              >
+                {title}
+              </h2>
+            </Col>
+          )}
+
+          {path_filters_buttons && (
+            <Col md={title ? 6 : 12} className="path-filter-buttons">
+              <div className="path-filter-buttons-wrapper">
+                {path_filters_buttons.map((button) => (
+                  <Button
+                    color="primary"
+                    outline={button.path['@id'] !== pathFilter}
+                    size="xs"
+                    icon={false}
+                    tag="button"
+                    className="ml-3"
+                    onClick={(e) => {
+                      addPathFilter(button.path['@id']);
+                    }}
+                  >
+                    {button.label}
+                  </Button>
+                ))}
+              </div>
+            </Col>
+          )}
         </Row>
       )}
 

--- a/src/config.js
+++ b/src/config.js
@@ -77,6 +77,7 @@ import { DettagliProcedimentiView } from '@italia/components/ItaliaTheme';
 
 import CardWithImageTemplate from '@italia/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate';
 import SmallBlockLinksTemplate from '@italia/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate';
+
 import CompleteBlockLinksTemplate from '@italia/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate';
 import PhotogalleryTemplate from '@italia/components/ItaliaTheme/Blocks/Listing/PhotogalleryTemplate';
 import InEvidenceTemplate from '@italia/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate';
@@ -380,6 +381,14 @@ const customBlocks = {
         label: 'Card con immagine',
         template: CardWithImageTemplate,
       },
+      inEvidenceTemplate: {
+        label: 'In evidenza',
+        template: InEvidenceTemplate,
+      },
+      ribbonCardTemplate: {
+        label: 'Card con nastro',
+        template: RibbonCardTemplate,
+      },
       smallBlockLinksTemplate: {
         label: 'Blocco link solo immagini',
         template: SmallBlockLinksTemplate,
@@ -392,17 +401,9 @@ const customBlocks = {
         label: 'Photogallery',
         template: PhotogalleryTemplate,
       },
-      inEvidenceTemplate: {
-        label: 'In evidenza',
-        template: InEvidenceTemplate,
-      },
       gridGalleryTemplate: {
         label: 'Gallery a griglia',
         template: GridGalleryTemplate,
-      },
-      ribbonCardTemplate: {
-        label: 'Card con nastro',
-        template: RibbonCardTemplate,
       },
       bandiInEvidenceTemplate: {
         label: 'Bandi',

--- a/src/customizations/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/src/customizations/components/manage/Blocks/Listing/ListingBody.jsx
@@ -24,8 +24,8 @@ const ListingBody = ({ data, properties, intl, path, isEditMode }) => {
   }, [data.query]);
 
   const doSearch = (data = { query: [] }, page = 1) => {
-    let _data = { ...data, query: [...data.query, ...additionalFilters] };
     if (data?.query?.length > 0 || additionalFilters.length > 0) {
+      let _data = { ...data, query: [...data.query, ...additionalFilters] };
       dispatch(
         getQueryStringResults(
           path,
@@ -39,7 +39,7 @@ const ListingBody = ({ data, properties, intl, path, isEditMode }) => {
         getQueryStringResults(
           path,
           {
-            ..._data,
+            ...data,
             fullobjects: 1,
             query: [
               {

--- a/theme/ItaliaTheme/Blocks/_simpleCardTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_simpleCardTemplate.scss
@@ -1,4 +1,22 @@
 .simple-card-default {
+  .template-header {
+    &.with-filters {
+      border-bottom: 1px solid $neutral-1-a2;
+      margin-bottom: 1em;
+
+      .path-filter-buttons {
+        display: flex;
+        align-items: flex-end;
+        justify-content: flex-end;
+      }
+
+      h2,
+      .path-filter-buttons-wrapper {
+        margin-bottom: 1rem;
+      }
+    }
+  }
+
   .data:before {
     content: none;
   }

--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -124,6 +124,18 @@ body.cms-ui {
     }
   }
 
+  .path-filter-widget {
+    padding: 1em 0 1em 0.5em;
+    margin-left: 2em;
+    border-left: 1px solid #edf1f2;
+
+    .filter-title {
+      background-color: #edf1f2;
+      padding: 0.5em;
+      margin-left: -0.5em;
+    }
+  }
+
   // .DraftEditor-root {
   //   font-family: $font-family-serif;
   //   h1,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/51911425/101933990-42d50500-3bdd-11eb-9137-377432c240c2.png)
In pratica, nel template 'Card semplice' del listing, è possibile spuntare una opzione per aggiungere dei bottoni che consentono all'utente di filtrare ulteriormente i risultati per path. Per ogni bottone si può indicare la label e il percorso su cui filtrare gli elementi. 