### PR TITLE
feat: remove tags as default

### DIFF
--- a/src/components/ItaliaTheme/View/Commons/Metadata.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Metadata.jsx
@@ -30,7 +30,7 @@ const messages = defineMessages({
  * @params {object} content: Content object.
  * @returns {string} Markup of the component.
  */
-const Metadata = ({ content, showTags = true, noMargin = false, children }) => {
+const Metadata = ({ content, showTags = false, noMargin = false, children }) => {
   const intl = useIntl();
   return (
     <article


### PR DESCRIPTION
Se nelle categorie non abbiamo valori significativi e non le usiamo per mandare alla ricerca, allora forse vale la pena non mostrarle.
Rimane possibile mostrarle per alcune viste aggiungendo la prop