### PR TITLE
Yarn i18n on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,16 @@
     },
     "ignoreFiles": "theme/themes/default/**/*.overrides"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "src/**/*.{jsx}": [
+      "yarn i18n"
+    ]
+  },
   "engines": {
     "node": "^10 || ^12"
   },

--- a/package.json
+++ b/package.json
@@ -125,14 +125,10 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "yarn i18n && git add ."
     }
   },
-  "lint-staged": {
-    "src/**/*.{jsx}": [
-      "yarn i18n"
-    ]
-  },
+
   "engines": {
     "node": "^10 || ^12"
   },


### PR DESCRIPTION
quando si fa un commit, prima del commit viene lanciato yarn i18n e i file delle traduzioni vengono automaticamente aggiunti al commit. 
In questo modo siamo sempre sicuri di avere le traduzioni generate, anche in fase di creazione di un nuovo sito 