### PR TITLE
fix(a11y): grid gallery listing darker

### DIFF
--- a/theme/ItaliaTheme/Blocks/_gridGalleryTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_gridGalleryTemplate.scss
@@ -151,9 +151,9 @@
           right: 0;
           bottom: 0;
           left: 0;
-          background: rgba(0, 0, 0, 0.5);
+          background: rgba(0, 0, 0, 0.6);
           content: '';
-          opacity: 0.4;
+          opacity: 0.75;
           transition: opacity 0.3s ease;
         }
 
@@ -164,7 +164,7 @@
           }
 
           &::before {
-            opacity: 0.7;
+            opacity: 1;
           }
         }
       }


### PR DESCRIPTION
il testo bianco sulle fotografie non è sempre leggibile. Essendo un modello generale, dovrebbe essere pensato per evitare il rischio di situazioni non accessbili. Serve quindi al testo, qualcosa tipo uno sfondo semiopaco scuro per garantire sempre la leggibilità es. RGB(0,0,0,0.6).
Come ora previsto per l’hover, metterei uno sfondo sempre da scurire all'hover/focus