### PR TITLE
chore: enable translation for siteProperties

### DIFF
--- a/src/components/ItaliaTheme/Footer/FooterMain.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterMain.jsx
@@ -5,13 +5,15 @@
 
 import React from 'react';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
+import { useIntl } from 'react-intl';
+
 import { UniversalLink } from '@plone/volto/components';
 import {
   FooterNavigation,
   FooterInfos,
   LogoFooter,
 } from '@italia/components/ItaliaTheme/';
-import config from '@plone/volto/registry';
+import { getSiteProperty } from '@italia/helpers';
 
 /**
  * FooterMain component class.
@@ -19,6 +21,7 @@ import config from '@plone/volto/registry';
  * @extends Component
  */
 const FooterMain = () => {
+  const intl = useIntl();
   return (
     <div className="it-footer-main">
       <Container tag="div">
@@ -30,10 +33,10 @@ const FooterMain = () => {
                   <LogoFooter />
                   <div className="it-brand-text">
                     <h2 className="no_toc">
-                      {config.settings.siteProperties.siteTitle}
+                      {getSiteProperty('siteTitle', intl.locale)}
                     </h2>
                     <h3 className="no_toc d-none d-md-block">
-                      {config.settings.siteProperties.siteSubtitle}
+                      {getSiteProperty('siteSubtitle', intl.locale)}
                     </h3>
                   </div>
                 </UniversalLink>

--- a/src/components/ItaliaTheme/Footer/FooterSmall.jsx
+++ b/src/components/ItaliaTheme/Footer/FooterSmall.jsx
@@ -7,7 +7,7 @@ import React, { useState, useEffect } from 'react';
 import { UniversalLink } from '@plone/volto/components';
 import { defineMessages, useIntl } from 'react-intl';
 import { Container } from 'design-react-kit/dist/design-react-kit';
-import config from '@plone/volto/registry';
+import { getSiteProperty } from '@italia/helpers';
 
 const messages = defineMessages({
   goToPage: {
@@ -26,16 +26,7 @@ const FooterSmall = () => {
   const [links, setLinks] = useState([]);
 
   useEffect(() => {
-    const smallFooterLinks_config =
-      config.settings.siteProperties?.smallFooterLinks;
-    let _links = smallFooterLinks_config['default'] ?? [];
-    if (
-      config.settings.isMultilingual &&
-      smallFooterLinks_config?.[intl.locale]
-    ) {
-      _links = smallFooterLinks_config?.[intl.locale];
-    }
-
+    let _links = getSiteProperty('smallFooterLinks', intl.locale) ?? [];
     setLinks(_links);
   }, [intl.locale]);
 

--- a/src/components/ItaliaTheme/Header/HeaderCenter.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderCenter.jsx
@@ -21,7 +21,7 @@ import {
   SocialHeader,
   SubsiteSocialHeader,
 } from '@italia/components/ItaliaTheme';
-import config from '@plone/volto/registry';
+import { getSiteProperty } from '@italia/helpers';
 
 const messages = defineMessages({
   search: {
@@ -46,11 +46,11 @@ const HeaderCenter = () => {
             <Logo />
             <div className="it-brand-text">
               <h2 className="no_toc">
-                {subsite?.title || config.settings.siteProperties.siteTitle}
+                {subsite?.title || getSiteProperty('siteTitle', intl.locale)}
               </h2>
               <h3 className="no_toc d-none d-md-block">
                 {subsite?.description ||
-                  config.settings.siteProperties.siteSubtitle}
+                  getSiteProperty('siteSubtitle', intl.locale)}
               </h3>
             </div>
           </UniversalLink>

--- a/src/components/ItaliaTheme/Header/HeaderSlim.jsx
+++ b/src/components/ItaliaTheme/Header/HeaderSlim.jsx
@@ -12,17 +12,20 @@ import {
   HeaderContent,
   HeaderRightZone,
 } from 'design-react-kit/dist/design-react-kit';
-import config from '@plone/volto/registry';
+import { useIntl } from 'react-intl';
+import { getSiteProperty } from '@italia/helpers';
 
 const HeaderSlim = () => {
   const subsite = useSelector((state) => state.subsite?.data);
+  const intl = useIntl();
 
   const parentSiteURL = subsite
     ? '/'
-    : config.settings.siteProperties.parentSiteURL;
+    : getSiteProperty('parentSiteURL', intl.locale);
+
   const parentSiteTile = subsite
-    ? config.settings.siteProperties.subsiteParentSiteTitle
-    : config.settings.siteProperties.parentSiteTitle;
+    ? getSiteProperty('subsiteParentSiteTitle', intl.locale)
+    : getSiteProperty('parentSiteTitle', intl.locale);
 
   const target = subsite ? null : '_blank';
   return (

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -435,8 +435,8 @@ export default function applyConfig(voltoConfig) {
     devProxyToApiPath: 'http://localhost:8080/Plone',
 
     // listBlockTypes: listBlockTypes,
-    isMultilingual: false,
-    supportedLanguages: ['it'],
+    isMultilingual: true,
+    supportedLanguages: ['it', 'en'],
     defaultLanguage: 'it',
     verticalFormTabs: true,
     contentIcons: {
@@ -463,11 +463,11 @@ export default function applyConfig(voltoConfig) {
       imagePosition: 'afterHeader', // possible values: afterHeader, documentBody
     },
     siteProperties: {
-      siteTitle: 'Nome del Comune',
-      siteSubtitle: "Uno dei tanti Comuni d'Italia",
-      parentSiteTitle: 'Nome della Regione',
-      parentSiteURL: 'https://www.governo.it',
-      subsiteParentSiteTitle: 'Nome del sito padre del sottosito',
+      siteTitle: 'Nome del Comune', //può essere una stringa, o un oggetto nel caso di multilingua: {'it':'Nome del Comune', 'en':'Site name'}. Se multilingua il default è comunque la stringa.
+      siteSubtitle: "Uno dei tanti Comuni d'Italia", //può essere una stringa, o un oggetto nel caso di multilingua: {'it':'Uno dei tanti Comuni d'Italia', 'en':'Uno dei tanti Comuni d'Italia'}. Se multilingua il default è comunque la stringa.
+      parentSiteTitle: 'Nome della Regione', //può essere una stringa, o un oggetto nel caso di multilingua: {'it':'Nome della Regione', 'en':'Region name'}.Se multilingua il default è comunque la stringa.
+      parentSiteURL: 'https://www.governo.it', //può essere una stringa, o un oggetto nel caso di multilingua: {'it':'https://www.governo.it', 'en':'https://www.governo.it/en'}. Se multilingua il default è comunque la stringa.
+      subsiteParentSiteTitle: 'Nome del sito padre del sottosito', //può essere una stringa, o un oggetto nel caso di multilingua: {'it':'Nome del sito padre', 'en':'Parent site name'}. Se multilingua il default è comunque la stringa.
       amministrazioneTrasparenteUrl: '/amministrazione-trasparente',
       // arLoginUrl: 'https://io-comune.agamar.redturtle.it/login',
       // arLogoutUrl: 'https://io-comune.agamar.redturtle.it/logout',
@@ -488,9 +488,9 @@ export default function applyConfig(voltoConfig) {
         ],
         en: [
           { title: 'Media policy', url: '/en/media-policy' },
-          { title: 'Note legali', url: '/en/legal-notes' },
+          { title: 'Legal notes', url: '/en/legal-notes' },
           { title: 'Privacy policy', url: '/en/privacy-policy' },
-          { title: 'Mappa del sito', url: '/en/sitemap' },
+          { title: 'Sitemap', url: '/en/sitemap' },
           { title: 'Credits', url: 'https://www.redturtle.it/' },
         ],
       },

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -435,8 +435,8 @@ export default function applyConfig(voltoConfig) {
     devProxyToApiPath: 'http://localhost:8080/Plone',
 
     // listBlockTypes: listBlockTypes,
-    isMultilingual: true,
-    supportedLanguages: ['it', 'en'],
+    isMultilingual: false,
+    supportedLanguages: ['it'],
     defaultLanguage: 'it',
     verticalFormTabs: true,
     contentIcons: {

--- a/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
+++ b/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { connect, useSelector } from 'react-redux';
-import { Helmet } from '@plone/volto/helpers';
+import { useIntl } from 'react-intl';
+import { useLocation } from 'react-router-dom';
+
+import { Helmet, BodyClass } from '@plone/volto/helpers';
+import { RemoveBodyClass } from '@italia/components/ItaliaTheme';
+import { getSiteProperty } from '@italia/helpers';
 import ScrollToTop from '@italia/components/ItaliaTheme/ScrollToTop/ScrollToTop';
 import { SubsiteLoader } from '@italia/addons/volto-subsites';
 
-import { useLocation } from 'react-router-dom';
-import { BodyClass } from '@plone/volto/helpers';
-import { RemoveBodyClass } from '@italia/components/ItaliaTheme';
-
-import config from '@plone/volto/registry';
-
 const AppExtras = ({ pathname }) => {
+  const intl = useIntl();
   const subsite = useSelector((state) => state.subsite?.data);
-  const siteTitle =
-    subsite?.title ?? config.settings?.siteProperties?.siteTitle;
+  const siteTitle = subsite?.title ?? getSiteProperty('siteTitle', intl.locale);
 
   const location = useLocation();
 

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -5,20 +5,18 @@
 
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-
-import {
-  getDropdownMenuNavitems,
-  getItemsByPath,
-} from '@italia/addons/volto-dropdownmenu';
+import { useIntl } from 'react-intl';
 import {
   Header,
   HeaderContent,
   HeaderToggler,
   Nav,
 } from 'design-react-kit/dist/design-react-kit';
+
+import { flattenToAppURL } from '@plone/volto/helpers';
+
 import { Collapse } from '@italia/components';
 import {
   MegaMenu,
@@ -28,10 +26,14 @@ import {
   SocialHeader,
   SubsiteSocialHeader,
 } from '@italia/components/ItaliaTheme';
-import { flattenToAppURL } from '@plone/volto/helpers';
-import config from '@plone/volto/registry';
+import { getSiteProperty } from '@italia/helpers';
+import {
+  getDropdownMenuNavitems,
+  getItemsByPath,
+} from '@italia/addons/volto-dropdownmenu';
 
 const Navigation = ({ pathname }) => {
+  const intl = useIntl();
   const [collapseOpen, setCollapseOpen] = useState(false);
   const dispatch = useDispatch();
   const subsite = useSelector((state) => state.subsite?.data);
@@ -102,11 +104,11 @@ const Navigation = ({ pathname }) => {
                   <div className="it-brand-text">
                     <h2 className="no_toc">
                       {subsite?.title ||
-                        config.settings.siteProperties.siteTitle}
+                        getSiteProperty('siteTitle', intl.locale)}
                     </h2>
                     <h3 className="no_toc">
                       {subsite?.description ||
-                        config.settings.siteProperties.siteSubtitle}
+                        getSiteProperty('siteSubtitle', intl.locale)}
                     </h3>
                   </div>
                 </Link>

--- a/src/helpers/config.js
+++ b/src/helpers/config.js
@@ -1,0 +1,22 @@
+import config from '@plone/volto/registry';
+
+export const getSiteProperty = (property, locale) => {
+  let value = config.settings.siteProperties[property];
+
+  if (value) {
+    switch (typeof value) {
+      case 'string':
+        return value;
+      case 'object':
+        return (
+          value[locale] ??
+          value.default ??
+          value[config.settings.defaultLanguage] ??
+          value
+        );
+      default:
+        break;
+    }
+  }
+  return null;
+};

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -13,3 +13,4 @@ export {
 export { contentFolderHasItems } from '@italia/helpers/contentHelper';
 export { getTableRowData } from '@italia/helpers/amministrazioneTrasparenteHelper';
 export { getItemsByPath } from '@italia/helpers/getItemsByPath';
+export { getSiteProperty } from '@italia/helpers/config';


### PR DESCRIPTION
Permette di poter tradurre le properties del sito per i siti multilingua. 

Come funziona:
- se la property è una stringa viene usata la stringa
- se la property è un oggetto:
   -- se nell'oggetto c'è una property con la lingua corrente, viene preso il valore di quella property, oppure il valore della property 'default' (es. di oggetto: {'default':'Nome del sito', 'it':'Nome del sito', 'en': 'Site name'}
  -- se nell'oggetto non c'è nè la property corrispondente alla lingua corrente, nè la property 'default' viene ritornato l'oggetto stesso.

In questo modo non dobbiamo cambiare la configurazione dei siti che abbiamo già, e dobbiamo eventualmente farlo solo per i siti multilingua