### PR TITLE
ci: add develop workflow

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -82,7 +82,7 @@ jobs:
           cluster-id: ${{ secrets.RANCHER_CLUSTER_ID }}
           project-id: ${{ secrets.RANCHER_PROJECT_ID }}
           namespace: ${{ secrets.RANCHER_NAMESPACE }}
-          workload: ${{ secrets.RANCHER_WORKLOAD }}
+          workload: ${{ secrets.RANCHER_WORKLOAD_DEVELOP }}
           image: redturtletech/io-comune-base:develop
           slack-hook-url: ${{ secrets.RANCHER_SLACK_HOOK_URL }}
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,88 @@
+# This is a basic workflow to help you get started with Actions
+name: Docker build for latest develop version
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow when a pull request is approved
+  pull_request_review:
+    types: [submitted]
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  #workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Runs only if pull request is approved
+    if: github.event.review.state == 'approved'
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    # Will be run if pull request is approved
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Merge branch in develop
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          label_name: 'In develop'
+          target_branch: develop
+          github_token: ${{ github.token }}
+
+      - name: Switch to develop
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker images
+        # You may pin to the exact commit or the version.
+        # uses: docker/build-push-action@4a531fa5a603bab87dfa56578bd82b28508c9547
+        uses: docker/build-push-action@v2
+        with:
+          # List of tags
+          tags: redturtletech/io-comune-base:develop
+          # Always attempt to pull a newer version of the image
+          pull: true
+          # Push is a shorthand for --output=type=registry
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Deploy to rancher
+        uses: redturtle/rancher-deploy-action@v0.1.0
+        with:
+          host: ${{ secrets.RANCHER_HOST }}
+          api-username: ${{ secrets.RANCHER_API_USERNAME }}
+          api-password: ${{ secrets.RANCHER_API_PASSWORD }}
+          cluster-id: ${{ secrets.RANCHER_CLUSTER_ID }}
+          project-id: ${{ secrets.RANCHER_PROJECT_ID }}
+          namespace: ${{ secrets.RANCHER_NAMESPACE }}
+          workload: ${{ secrets.RANCHER_WORKLOAD }}
+          image: redturtletech/io-comune-base:develop
+          slack-hook-url: ${{ secrets.RANCHER_SLACK_HOOK_URL }}
+

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,12 +3,11 @@ name: Docker build for latest master version
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
+  # Triggers the workflow on releases
+  release:
+    types: [published]
   #pull_request:
-    #branches: [ master ]
-
+  #branches: [ master ]
   # Allows you to run this workflow manually from the Actions tab
   #workflow_dispatch:
 


### PR DESCRIPTION
Add a workflow to run on pull request approval.
This workflow merge the active PR branch into `develop` and deploys it to rancher.

The "master" workflow is now running on releases only