### PR TITLE
chore: added brand icons and enabled usage of regular icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.30",
+    "@fortawesome/free-brands-svg-icons": "5.14.0",
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",

--- a/src/components/ItaliaTheme/Icons/Icon.jsx
+++ b/src/components/ItaliaTheme/Icons/Icon.jsx
@@ -22,10 +22,16 @@ const Icon = (props) => {
       size,
     );
 
+    const parts = icon.split(' ');
     return icon.indexOf('it-') === 0 ? (
       <DesignIcon {...props} className={classes} />
     ) : icon === 'telegram' ? (
       <TelegramSVG className={classes} />
+    ) : parts.length > 1 ? (
+      <FontAwesomeIcon
+        icon={[parts[0], parts[1]]}
+        className={`fal ${classes}`}
+      />
     ) : (
       <FontAwesomeIcon icon={icon} className={`fal ${classes}`} />
     );

--- a/src/components/ItaliaTheme/manage/Widgets/IconPreviewWidget.jsx
+++ b/src/components/ItaliaTheme/manage/Widgets/IconPreviewWidget.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { defineMessages, useIntl } from 'react-intl';
-import { Form, Grid, Label } from 'semantic-ui-react';
+import { Form, Grid } from 'semantic-ui-react';
 
 const messages = defineMessages({
   previewIconSelected: {
@@ -13,7 +13,7 @@ const messages = defineMessages({
 
 const IconPreviewWidget = ({ icon, onEdit, title, description, children }) => {
   const intl = useIntl();
-
+  const parts = icon.split(' ');
   return (
     <Form.Field inline className="help" id="icon-preview-widget-id">
       <Grid>
@@ -27,7 +27,16 @@ const IconPreviewWidget = ({ icon, onEdit, title, description, children }) => {
             <div className="ui input flex-center">
               <p className="help">
                 {icon ? (
-                  <FontAwesomeIcon icon={icon} className="show-icon" />
+                  <>
+                    {parts.length > 1 ? (
+                      <FontAwesomeIcon
+                        icon={[parts[0], parts[1]]}
+                        className="show-icon"
+                      />
+                    ) : (
+                      <FontAwesomeIcon icon={icon} className="show-icon" />
+                    )}
+                  </>
                 ) : (
                   <span>
                     {intl.formatMessage(messages.previewIconSelected)}

--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -116,6 +116,7 @@ import { defaultIconWidgetOptions } from '@italia/helpers/index';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import * as Icons from '@fortawesome/free-solid-svg-icons';
 import * as IconsRegular from '@fortawesome/free-regular-svg-icons';
+import * as IconsBrands from '@fortawesome/free-brands-svg-icons';
 
 // CTs icons
 import faFileInvoiceSVG from '@italia/icons/file-invoice.svg';
@@ -142,7 +143,11 @@ const iconListRegular = Object.keys(IconsRegular.far).map(
   (icon) => IconsRegular[icon],
 );
 
-library.add(...iconList, ...iconListRegular);
+const iconListBrands = Object.keys(IconsBrands.fab).map(
+  (icon) => IconsBrands[icon],
+);
+
+library.add(...iconList, ...iconListRegular, ...iconListBrands);
 
 export default function applyConfig(voltoConfig) {
   let config = applyRichTextConfig(voltoConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,6 +1445,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.30"
 
+"@fortawesome/free-brands-svg-icons@5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.14.0.tgz#98555518ba41bdff82fbae2f4d1bc36cd3b1c043"
+  integrity sha512-WsqPFTvJFI7MYkcy0jeFE2zY+blC4OrnB9MJOcn1NxRXT/sSfEEhrI7CwzIkiYajLiVDBKWeErYOvpsMeodmCQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.30"
+
 "@fortawesome/free-regular-svg-icons@5.14.0":
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.14.0.tgz#ca513ac7699625af42938744297ac483361da043"


### PR DESCRIPTION
Now you can use far and fab icon set (default is fas).
If you don't write prefix, default prefix is 'fas'.
If you want icons from 'Regular' or from 'Brands' set, you could add prefix before icon name, for example: 'far angry' or 'fab accessible-icon'. 
Writing 'angry' or 'fas angry' is the same.