### PR TITLE
feat: added new subsites colors

### DIFF
--- a/theme/ItaliaTheme/Subsites/_mixin.scss
+++ b/theme/ItaliaTheme/Subsites/_mixin.scss
@@ -6,7 +6,8 @@
   $subsite-secondary-text: $secondary-text,
   $subsite-tertiary: $tertiary,
   $subsite-tertiary-text: $tertiary-text,
-  $subsite-link-color: $link-color
+  $subsite-link-color: $link-color,
+  $subsite-light-theme: false
 ) {
   body.subsite-#{$subsite-style} {
     @import 'bootstrap-italia/custom/header';

--- a/theme/ItaliaTheme/Subsites/_templates.scss
+++ b/theme/ItaliaTheme/Subsites/_templates.scss
@@ -1,0 +1,160 @@
+@import 'ItaliaTheme/Subsites/mixin';
+
+// ----------------- YELLOW ----------------- //
+$subsite-yellow-primary: #d4a418;
+$subsite-yellow-primary-text: black;
+$subsite-yellow-secondary: green;
+$subsite-yellow-secondary-text: white;
+$subsite-yellow-link-color: #b77d04;
+
+@include define-subsite(
+  'yellow',
+  $subsite-yellow-primary,
+  $subsite-yellow-primary-text,
+  $subsite-yellow-secondary,
+  $subsite-yellow-secondary-text,
+  $tertiary,
+  $tertiary-text,
+  $subsite-yellow-link-color,
+  true
+);
+
+// ----------------- LIGHT YELLOW ----------------- //
+$subsite-light-yellow-primary: #f6eac5;
+$subsite-light-yellow-primary-text: #000;
+$subsite-light-yellow-secondary: #b77d04;
+$subsite-light-yellow-secondary-text: #000;
+$subsite-light-yellow-tertiary: #8b5d0a;
+$subsite-light-yellow-tertiary-text: #fff;
+$subsite-light-yellow-link-color: #b77d04;
+
+@include define-subsite(
+  'light-yellow',
+  $subsite-light-yellow-primary,
+  $subsite-light-yellow-primary-text,
+  $subsite-light-yellow-secondary,
+  $subsite-light-yellow-secondary-text,
+  $subsite-light-yellow-tertiary,
+  $subsite-light-yellow-tertiary-text,
+  $subsite-light-yellow-link-color,
+  true
+);
+@import 'ItaliaTheme/Subsites/templates/light-yellow';
+
+// ----------------- LIGHT-BLUE ----------------- //
+$subsite-light-blue-primary: #72a9f9;
+$subsite-light-blue-primary-text: #000;
+$subsite-light-blue-tertiary: #2e4d7b;
+$subsite-light-blue-tertiary-text: #fff;
+$subsite-light-blue-link-color: #235eb6;
+
+@include define-subsite(
+  'light-blue',
+  $subsite-light-blue-primary,
+  $subsite-light-blue-primary-text,
+  $subsite-light-blue-primary,
+  $subsite-light-blue-primary-text,
+  $subsite-light-blue-tertiary,
+  $subsite-light-blue-tertiary-text,
+  $subsite-light-blue-link-color,
+  true
+);
+
+// ----------------- TEAL ----------------- //
+$subsite-teal-primary: #2f707b;
+$subsite-teal-primary-text: white;
+$subsite-teal-tertiary: #178567;
+$subsite-teal-tertiary-text: white;
+
+@include define-subsite(
+  'teal',
+  $subsite-teal-primary,
+  $subsite-teal-primary-text,
+  $subsite-teal-primary,
+  $subsite-teal-primary-text,
+  $subsite-teal-tertiary,
+  $subsite-teal-tertiary-text,
+  $subsite-teal-primary
+);
+
+// ----------------- LIGHT TEAL ----------------- //
+$subsite-light-teal-primary: #d9e9e8;
+$subsite-light-teal-primary-text: #000;
+$subsite-light-teal-secondary: #d9e9e8;
+$subsite-light-teal-secondary-text: #000;
+$subsite-light-teal-tertiary: #2c7b78;
+$subsite-light-teal-tertiary-text: #fff;
+$subsite-light-teal-link-color: #2c7b78;
+
+@include define-subsite(
+  'light-teal',
+  $subsite-light-teal-primary,
+  $subsite-light-teal-primary-text,
+  $subsite-light-teal-secondary,
+  $subsite-light-teal-secondary-text,
+  $subsite-light-teal-tertiary,
+  $subsite-light-teal-tertiary-text,
+  $subsite-light-teal-link-color,
+  true
+);
+@import 'ItaliaTheme/Subsites/templates/light-teal';
+
+// ----------------- WHITE ----------------- //
+$subsite-white-primary: #0066cc;
+$subsite-white-primary-text: #fff;
+$subsite-white-secondary: #000eb3;
+$subsite-white-secondary-text: #fff;
+$subsite-white-link-color: #0066cc;
+
+@include define-subsite(
+  'white',
+  $subsite-white-primary,
+  $subsite-white-primary-text,
+  $subsite-white-primary,
+  $subsite-white-primary-text,
+  $tertiary,
+  $tertiary-text,
+  $subsite-white-link-color
+);
+
+@import 'ItaliaTheme/Subsites/templates/white';
+
+// ----------------- MAGENTA ----------------- //
+$subsite-magenta-primary: #be0042;
+$subsite-magenta-primary-text: #fff;
+$subsite-magenta-secondary: #3f091b;
+$subsite-magenta-secondary-text: #fff;
+$subsite-magenta-link-color: #be0042;
+
+@include define-subsite(
+  'magenta',
+  $subsite-magenta-primary,
+  $subsite-magenta-primary-text,
+  $subsite-magenta-primary,
+  $subsite-magenta-primary-text,
+  $subsite-magenta-primary,
+  $subsite-magenta-primary-text,
+  $subsite-magenta-link-color
+);
+
+// ----------------- LIGHT PINK ----------------- //
+$subsite-light-pink-primary: #faeef1;
+$subsite-light-pink-primary-text: #000;
+$subsite-light-pink-secondary: #faeef1;
+$subsite-light-pink-secondary-text: #000;
+$subsite-light-pink-tertiary: #b97787;
+$subsite-light-pink-tertiary-text: #fff;
+$subsite-light-pink-link-color: #9a264d;
+
+@include define-subsite(
+  'light-pink',
+  $subsite-light-pink-primary,
+  $subsite-light-pink-primary-text,
+  $subsite-light-pink-secondary,
+  $subsite-light-pink-secondary-text,
+  $subsite-light-pink-tertiary,
+  $subsite-light-pink-tertiary-text,
+  $subsite-light-pink-link-color,
+  true
+);
+@import 'ItaliaTheme/Subsites/templates/light-pink';

--- a/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_chips.scss
+++ b/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_chips.scss
@@ -1,16 +1,25 @@
 //mobile
 .chip {
   &.chip-primary {
-    border-color: $subsite-primary;
-    color: $subsite-primary;
-
-    & > .chip-label {
+    @if $subsite-light-theme {
+      border-color: darken($subsite-primary, 10);
+      color: darken($subsite-primary, 10);
+    } @else {
+      border-color: $subsite-primary;
       color: $subsite-primary;
     }
 
+    & > .chip-label {
+      @if $subsite-light-theme {
+        color: darken($subsite-primary, 10);
+      } @else {
+        color: $subsite-primary;
+      }
+    }
+
     &:hover {
-      background-color: $subsite-primary;
       border-color: $subsite-primary;
+      background-color: $subsite-primary;
 
       & > .chip-label {
         color: $subsite-primary-text;
@@ -27,8 +36,8 @@
     }
 
     &:hover {
-      background-color: $subsite-secondary;
       border-color: $subsite-secondary;
+      background-color: $subsite-secondary;
 
       & > .chip-label {
         color: $subsite-secondary-text;

--- a/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_header.scss
+++ b/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_header.scss
@@ -23,7 +23,11 @@
               a {
                 &.rounded-icon {
                   svg {
-                    fill: $subsite-primary;
+                    @if $subsite-light-theme {
+                      fill: $subsite-primary-text;
+                    } @else {
+                      fill: $subsite-primary;
+                    }
                   }
                 }
               }

--- a/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_headercenter.scss
+++ b/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_headercenter.scss
@@ -16,19 +16,24 @@
         .it-socials {
           ul {
             .icon {
-              fill: $subsite-primary-text;
               color: $subsite-primary-text;
+              fill: $subsite-primary-text;
             }
           }
         }
       }
 
       //-search
+
       .it-search-wrapper {
         a {
           &.rounded-icon {
             svg {
-              fill: $subsite-primary-text;
+              @if $subsite-light-theme {
+                fill: $subsite-primary-text;
+              } @else {
+                fill: $subsite-primary;
+              }
             }
           }
         }
@@ -47,8 +52,8 @@
               a {
                 &:hover {
                   svg {
-                    fill: darken($subsite-primary-text, 5%);
                     color: darken($subsite-primary-text, 5%);
+                    fill: darken($subsite-primary-text, 5%);
                   }
                 }
               }
@@ -61,7 +66,11 @@
           a {
             &.rounded-icon {
               svg {
-                fill: $subsite-primary;
+                @if $subsite-light-theme {
+                  fill: $subsite-primary-text;
+                } @else {
+                  fill: $subsite-primary;
+                }
               }
             }
           }

--- a/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_navigation.scss
+++ b/theme/ItaliaTheme/Subsites/bootstrap-italia/custom/_navigation.scss
@@ -5,10 +5,18 @@
     .navbar-nav {
       li {
         a.nav-link {
-          color: $subsite-primary;
+          @if $subsite-light-theme {
+            color: $subsite-primary-text;
+          } @else {
+            color: $subsite-primary;
+          }
 
           &.active {
-            border-left-color: $subsite-primary;
+            @if $subsite-light-theme {
+              border-left-color: $subsite-primary-text;
+            } @else {
+              border-left-color: $subsite-primary;
+            }
           }
         }
       }
@@ -25,7 +33,11 @@
           }
 
           span {
-            color: $subsite-link-color;
+            @if $subsite-light-theme {
+              color: darken($subsite-link-color, 10);
+            } @else {
+              color: $subsite-link-color;
+            }
           }
 
           i {

--- a/theme/ItaliaTheme/Subsites/templates/_light-pink.scss
+++ b/theme/ItaliaTheme/Subsites/templates/_light-pink.scss
@@ -1,0 +1,19 @@
+body.subsite-light-pink {
+  .chip.chip-primary {
+    border-color: $subsite-light-pink-link-color;
+    color: $subsite-light-pink-link-color;
+
+    & > .chip-label {
+      color: $subsite-light-pink-link-color;
+    }
+
+    &:hover {
+      border-color: $subsite-light-pink-link-color;
+      background-color: $subsite-light-pink-link-color;
+
+      & > .chip-label {
+        color: #fff;
+      }
+    }
+  }
+}

--- a/theme/ItaliaTheme/Subsites/templates/_light-teal.scss
+++ b/theme/ItaliaTheme/Subsites/templates/_light-teal.scss
@@ -1,0 +1,19 @@
+body.subsite-light-teal {
+  .chip.chip-primary {
+    border-color: $subsite-light-teal-link-color;
+    color: $subsite-light-teal-link-color;
+
+    & > .chip-label {
+      color: $subsite-light-teal-link-color;
+    }
+
+    &:hover {
+      border-color: $subsite-light-teal-link-color;
+      background-color: $subsite-light-teal-link-color;
+
+      & > .chip-label {
+        color: #fff;
+      }
+    }
+  }
+}

--- a/theme/ItaliaTheme/Subsites/templates/_light-yellow.scss
+++ b/theme/ItaliaTheme/Subsites/templates/_light-yellow.scss
@@ -1,0 +1,19 @@
+body.subsite-light-yellow {
+  .chip.chip-primary {
+    border-color: $subsite-light-yellow-link-color;
+    color: $subsite-light-yellow-link-color;
+
+    & > .chip-label {
+      color: $subsite-light-yellow-link-color;
+    }
+
+    &:hover {
+      border-color: $subsite-light-yellow-link-color;
+      background-color: $subsite-light-yellow-link-color;
+
+      & > .chip-label {
+        color: #fff;
+      }
+    }
+  }
+}

--- a/theme/ItaliaTheme/Subsites/templates/_white.scss
+++ b/theme/ItaliaTheme/Subsites/templates/_white.scss
@@ -1,0 +1,95 @@
+body.subsite-white {
+  //mobile
+  .it-header-wrapper {
+    box-shadow: 0px -10px 20px 0px $subsite-white-primary;
+
+    .it-header-center-wrapper {
+      background-color: $subsite-white-primary-text;
+      color: $subsite-white-primary;
+
+      //-search
+      .it-header-center-content-wrapper {
+        .it-brand-wrapper {
+          a {
+            color: $subsite-white-primary;
+          }
+
+          .it-brand-text {
+            h2,
+            h3 {
+              color: $subsite-white-primary;
+            }
+          }
+        }
+
+        .it-search-wrapper {
+          a {
+            width: 48px;
+            height: 48px;
+          }
+        }
+
+        .it-right-zone {
+          color: $subsite-white-primary;
+
+          a {
+            color: $subsite-white-primary;
+          }
+
+          .it-socials {
+            ul {
+              .icon {
+                color: $subsite-white-primary;
+                fill: $subsite-white-primary;
+              }
+
+              a {
+                &:hover {
+                  .icon {
+                    color: lighten($subsite-white-primary, 10);
+                    fill: lighten($subsite-white-primary, 10);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    .it-header-navbar-wrapper {
+      background-color: $subsite-white-primary-text;
+      color: $subsite-white-primary;
+
+      a {
+        color: $subsite-white-primary;
+      }
+
+      .navbar {
+        background-color: $subsite-white-primary-text;
+      }
+
+      .custom-navbar-toggler {
+        svg {
+          color: $subsite-white-primary;
+          fill: $subsite-white-primary;
+        }
+      }
+    }
+  }
+
+  .navbar .navbar-collapsable .navbar-nav li a.nav-link {
+    color: $subsite-white-primary;
+    @media (min-width: #{map-get($grid-breakpoints, lg)}) {
+      &.active {
+        border-color: $subsite-white-primary;
+      }
+    }
+  }
+
+  .megamenu {
+    .megamenu-toggle-icon {
+      fill: $subsite-white-primary;
+    }
+  }
+}

--- a/theme/site.scss
+++ b/theme/site.scss
@@ -92,32 +92,4 @@
 @import 'ItaliaTheme/Print/servizio';
 @import 'ItaliaTheme/Print/blocks';
 
-@import 'ItaliaTheme/Subsites/mixin';
-$subsite-yellow-primary: #fcab02;
-$subsite-yellow-primary-text: black;
-$subsite-yellow-secondary: green;
-$subsite-yellow-secondary-text: white;
-$subsite-yellow-link-color: #b77d04;
-@include define-subsite(
-  'yellow',
-  $subsite-yellow-primary,
-  $subsite-yellow-primary-text,
-  $subsite-yellow-secondary,
-  $subsite-yellow-secondary-text,
-  $tertiary,
-  $tertiary-text,
-  $subsite-yellow-link-color
-);
-
-$ubsite-light-blue-primary: #048693;
-$ubsite-light-blue-primary-text: white;
-@include define-subsite(
-  'light-blue',
-  $ubsite-light-blue-primary,
-  $ubsite-light-blue-primary-text,
-  $ubsite-light-blue-primary,
-  $ubsite-light-blue-primary-text,
-  $tertiary,
-  $tertiary-text,
-  $ubsite-light-blue-primary
-);
+@import 'ItaliaTheme/Subsites/templates';


### PR DESCRIPTION
Aggiunti nuovi colori per i sottositi come previsto dallo studio grafico, che saranno:

- white
<img width="1600" alt="Schermata 2021-07-02 alle 13 23 50" src="https://user-images.githubusercontent.com/51911425/124267884-1eb92100-db39-11eb-9df2-f9ceea5aaaad.png">

- yellow
<img width="1600" alt="Schermata 2021-07-02 alle 13 24 17" src="https://user-images.githubusercontent.com/51911425/124267947-3395b480-db39-11eb-9b27-d4ec8d884662.png">


- magenta
<img width="1600" alt="Schermata 2021-07-02 alle 13 24 35" src="https://user-images.githubusercontent.com/51911425/124267907-24af0200-db39-11eb-889a-2b8699bfa212.png">

- teal
<img width="1601" alt="Schermata 2021-07-02 alle 13 24 51" src="https://user-images.githubusercontent.com/51911425/124267918-28db1f80-db39-11eb-8be7-f4d0144942c5.png">

- light-yellow
<img width="1600" alt="Schermata 2021-07-02 alle 13 25 46" src="https://user-images.githubusercontent.com/51911425/124267939-30022d80-db39-11eb-8902-9ce527bdd907.png">

- light-pink
<img width="1599" alt="Schermata 2021-07-02 alle 13 26 02" src="https://user-images.githubusercontent.com/51911425/124267965-385a6880-db39-11eb-8cdc-2132375f3159.png">

- light-teal
<img width="1600" alt="Schermata 2021-07-02 alle 13 26 15" src="https://user-images.githubusercontent.com/51911425/124267975-3bedef80-db39-11eb-855d-318fd32afb29.png">

- light-blue
<img width="1600" alt="Schermata 2021-07-02 alle 13 25 08" src="https://user-images.githubusercontent.com/51911425/124268066-5627cd80-db39-11eb-9f2d-00234e32066a.png">
