### PR TITLE
fix: megamenu close button outline

### DIFF
--- a/theme/bootstrap-override/bootstrap-italia/_megamenu.scss
+++ b/theme/bootstrap-override/bootstrap-italia/_megamenu.scss
@@ -65,6 +65,16 @@
       }
     }
 
+    .megamenu-close-button {
+      button {
+        &:active,
+        &:focus {
+          outline: 1px dotted;
+          outline: 5px auto -webkit-focus-ring-color;
+        }
+      }
+    }
+
     .it-external {
       .link-list-wrapper {
         @media (min-width: #{map-get($grid-breakpoints, lg)}) {


### PR DESCRIPTION
Pareva non raggiungibile, in realtà solo non visibile 