### PR TITLE
chore: fixed argument icon styles

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
@@ -42,7 +42,11 @@ const SimpleCardTemplateCompact = ({
             teaser
             key={index}
           >
-            {show_icon && <Icon icon={getItemIcon(item)} />}
+            {show_icon && (
+              <div className="icon-argument-container">
+                <Icon icon={getItemIcon(item)} />
+              </div>
+            )}
             <CardBody>
               <CardTitle tag="h3">
                 <UniversalLink

--- a/src/components/ItaliaTheme/View/Commons/Argument/ArgumentIcon.jsx
+++ b/src/components/ItaliaTheme/View/Commons/Argument/ArgumentIcon.jsx
@@ -10,7 +10,7 @@ import { Icon } from '@italia/components/ItaliaTheme';
  */
 const ArgumentIcon = ({ icon }) => {
   return icon ? (
-    <div className="icon-argument-container d-flex align-items-center justify-content-center mb-2 lightgrey-bg-c2">
+    <div className="icon-argument-container mb-2">
       <Icon icon={icon} />
     </div>
   ) : null;

--- a/theme/ItaliaTheme/Blocks/_simpleCardTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_simpleCardTemplate.scss
@@ -93,6 +93,16 @@
 
 .simple-card-compact-template {
   .card-teaser-wrapper {
+    .icon-argument-container + .card-body {
+      margin-left: 1em;
+    }
+
+    .card-teaser {
+      .icon {
+        min-width: unset;
+      }
+    }
+
     &.card-teaser-block-3 {
       & > .card-teaser {
         flex-wrap: nowrap;

--- a/theme/ItaliaTheme/Subsites/ItaliaTheme/Views/_common.scss
+++ b/theme/ItaliaTheme/Subsites/ItaliaTheme/Views/_common.scss
@@ -50,7 +50,7 @@
   }
 
   svg {
-    fill: $subsite-tertiary;
     color: $subsite-tertiary;
+    fill: $subsite-tertiary;
   }
 }

--- a/theme/ItaliaTheme/Views/_common.scss
+++ b/theme/ItaliaTheme/Views/_common.scss
@@ -254,19 +254,25 @@ div.sticky-wrapper {
 }
 
 .icon-argument-container {
+  display: flex;
+
   width: 44px;
+  min-width: 44px;
+
   height: 44px;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+
+  background-color: $argument-icon-bg;
   border-radius: 44px;
 
-  .show-icon {
+  .icon,
+  svg {
     width: 24px;
     height: 24px;
-    color: $tertiary;
-  }
-
-  svg {
-    color: $tertiary;
-    fill: $tertiary;
+    color: $argument-icon-color;
+    fill: $argument-icon-color;
   }
 }
 

--- a/theme/_site-variables.scss
+++ b/theme/_site-variables.scss
@@ -13,3 +13,6 @@ $secondary-text: #fff !default;
 $tertiary: #be2816 !default;
 $tertiary-text: #fff !default;
 $font-family-monospace-light: Roboto Mono Light;
+
+$argument-icon-color: $tertiary !default;
+$argument-icon-bg: #f5f6f7 !default;


### PR DESCRIPTION
Sistemata la gestione degli stili delle icone degli argomenti e la visualizzazione dell'icona nel template 'Card semplice - Compatto' del blocco elenco, secondo le grafiche agid.

Ora esistono due variabili: $argument-icon-color e $argument-icon-bg che si possono usare nei siti per cambiarne i colori. 
