### PR TITLE
chore: added listing SliderTemplate features

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -620,6 +620,74 @@ msgstr ""
 msgid "autoplay_speed_description"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "ay11_Use Up and Down to choose options"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select deselected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select disabled"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select for search term"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select is disabled. Select another option."
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select selected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__press Tab to select the option and exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__type to refine list"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_is_focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Down to open the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Enter to select the currently focused option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Escape to exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press left to focus selected values"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr ""

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -116,6 +116,7 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "Content in evidence"
 msgstr ""
@@ -216,11 +217,15 @@ msgstr ""
 msgid "Link to"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -251,6 +256,14 @@ msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
 msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
@@ -413,12 +426,14 @@ msgstr ""
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -427,6 +442,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -592,6 +608,18 @@ msgstr ""
 msgid "autenticazione"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed_description"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr ""
@@ -658,6 +686,7 @@ msgid "bando_vedi"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "bg_color"
 msgstr ""
@@ -730,10 +759,12 @@ msgid "closeSearch"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_primary"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_transparent"
 msgstr ""
@@ -771,6 +802,10 @@ msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
 msgid "contatti_interni"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Body
+msgid "content-in-evidence-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioView
@@ -991,7 +1026,9 @@ msgstr ""
 msgid "email_sede"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Edit
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1059,6 +1096,7 @@ msgstr ""
 msgid "exploreArgument"
 msgstr ""
 
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderTree
 #: components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar
 msgid "faq_search"
 msgstr "Typ een trefwoord om antwoorden te vinden"
@@ -1277,9 +1315,15 @@ msgstr ""
 msgid "modulo_formati_alternativi"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "natural_image_size"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Body
+msgid "newsHome-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/NewsItemView/NewsItemView
@@ -1435,6 +1479,10 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 msgid "playStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
@@ -1851,6 +1899,18 @@ msgstr ""
 msgid "select_argument_sidebar"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "select_noOptionsMessage"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultati"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultato"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "service_not_active"
 msgstr ""
@@ -1884,12 +1944,24 @@ msgstr ""
 msgid "show_detail_link"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_dots"
+msgstr ""
+
 #: config/Blocks/ListingOptions/bandiInEvidenceTemplate
 msgid "show_ente"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_full_width"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_image_title"
 msgstr ""
 
 #: config/Blocks/ListingOptions/mapTemplate
@@ -1900,6 +1972,7 @@ msgstr ""
 msgid "show_only_first_ribbon"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
@@ -1914,6 +1987,7 @@ msgstr ""
 msgid "show_topics"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_type"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -605,6 +605,74 @@ msgstr ""
 msgid "autoplay_speed_description"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "ay11_Use Up and Down to choose options"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select deselected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select disabled"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select for search term"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select is disabled. Select another option."
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select selected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__press Tab to select the option and exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__type to refine list"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_is_focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Down to open the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Enter to select the currently focused option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Escape to exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press left to focus selected values"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr "back"

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -101,6 +101,7 @@ msgstr "Contacts"
 msgid "Content"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "Content in evidence"
 msgstr ""
@@ -201,11 +202,15 @@ msgstr ""
 msgid "Link to"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -237,6 +242,14 @@ msgstr "Show all topics"
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
 msgstr "No results found"
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
+msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
 msgid "Next page"
@@ -398,12 +411,14 @@ msgstr "Drop the file here to replace existing file"
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -412,6 +427,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -577,6 +593,18 @@ msgstr "Act of appointment"
 msgid "autenticazione"
 msgstr "Authentication"
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed_description"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr "back"
@@ -643,6 +671,7 @@ msgid "bando_vedi"
 msgstr "View"
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "bg_color"
 msgstr ""
@@ -715,10 +744,12 @@ msgid "closeSearch"
 msgstr "Close search"
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_primary"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_transparent"
 msgstr ""
@@ -757,6 +788,10 @@ msgstr "External contacts"
 #: components/ItaliaTheme/View/EventoView/EventoView
 msgid "contatti_interni"
 msgstr "Internal contacts"
+
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Body
+msgid "content-in-evidence-news"
+msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "copertura_geografica"
@@ -976,7 +1011,9 @@ msgstr "E-mail"
 msgid "email_sede"
 msgstr "E-mail"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Edit
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1044,6 +1081,7 @@ msgstr "Explore"
 msgid "exploreArgument"
 msgstr "Explore topic"
 
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderTree
 #: components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar
 msgid "faq_search"
 msgstr "Type a keyword to find answers"
@@ -1262,10 +1300,16 @@ msgstr "Main file"
 msgid "modulo_formati_alternativi"
 msgstr "Alternative formats"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "natural_image_size"
 msgstr "Do not alter natural image sizes"
+
+#: components/ItaliaTheme/Blocks/NewsHome/Body
+msgid "newsHome-news"
+msgstr ""
 
 #: components/ItaliaTheme/View/NewsItemView/NewsItemView
 msgid "news_item_contenuto"
@@ -1420,6 +1464,10 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 msgid "playStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
@@ -1836,6 +1884,18 @@ msgstr "Select topics you want search for"
 msgid "select_argument_sidebar"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "select_noOptionsMessage"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultati"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultato"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "service_not_active"
 msgstr "The service is not active"
@@ -1869,12 +1929,24 @@ msgstr ""
 msgid "show_detail_link"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_dots"
+msgstr ""
+
 #: config/Blocks/ListingOptions/bandiInEvidenceTemplate
 msgid "show_ente"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_full_width"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_image_title"
 msgstr ""
 
 #: config/Blocks/ListingOptions/mapTemplate
@@ -1885,6 +1957,7 @@ msgstr ""
 msgid "show_only_first_ribbon"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
@@ -1899,6 +1972,7 @@ msgstr ""
 msgid "show_topics"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_type"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -622,6 +622,74 @@ msgstr ""
 msgid "autoplay_speed_description"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "ay11_Use Up and Down to choose options"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select deselected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select disabled"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select for search term"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select is disabled. Select another option."
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select selected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__press Tab to select the option and exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__type to refine list"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_is_focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Down to open the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Enter to select the currently focused option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Escape to exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press left to focus selected values"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr "retourner"

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -118,6 +118,7 @@ msgstr "Contacts"
 msgid "Content"
 msgstr "Contenu"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "Content in evidence"
 msgstr ""
@@ -218,11 +219,15 @@ msgstr ""
 msgid "Link to"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -254,6 +259,14 @@ msgstr "Afficher tous les sujets"
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
 msgstr "Aucun résultat obtenu"
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
+msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
 msgid "Next page"
@@ -415,12 +428,14 @@ msgstr "Faites glisser un fichier ici pour remplacer l'existant"
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -429,6 +444,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -594,6 +610,18 @@ msgstr "Acte de nomination"
 msgid "autenticazione"
 msgstr "Authentification"
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed_description"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr "retourner"
@@ -660,6 +688,7 @@ msgid "bando_vedi"
 msgstr "Voir"
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "bg_color"
 msgstr ""
@@ -732,10 +761,12 @@ msgid "closeSearch"
 msgstr "Fermer la recherche"
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_primary"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_transparent"
 msgstr ""
@@ -774,6 +805,10 @@ msgstr "Contacts externes"
 #: components/ItaliaTheme/View/EventoView/EventoView
 msgid "contatti_interni"
 msgstr "Contacts internes"
+
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Body
+msgid "content-in-evidence-news"
+msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "copertura_geografica"
@@ -993,7 +1028,9 @@ msgstr ""
 msgid "email_sede"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Edit
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1061,6 +1098,7 @@ msgstr "Explorer"
 msgid "exploreArgument"
 msgstr "Explorer le sujet"
 
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderTree
 #: components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar
 msgid "faq_search"
 msgstr "Tapez un mot-clé pour trouver des réponses"
@@ -1279,9 +1317,15 @@ msgstr "Dossier principal"
 msgid "modulo_formati_alternativi"
 msgstr "Formats alternatifs"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "natural_image_size"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Body
+msgid "newsHome-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/NewsItemView/NewsItemView
@@ -1437,6 +1481,10 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 msgid "playStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
@@ -1853,6 +1901,18 @@ msgstr "Sélectionnez les sujets que vous souhaitez rechercher"
 msgid "select_argument_sidebar"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "select_noOptionsMessage"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultati"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultato"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "service_not_active"
 msgstr "Le service n'est pas actif"
@@ -1886,12 +1946,24 @@ msgstr ""
 msgid "show_detail_link"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_dots"
+msgstr ""
+
 #: config/Blocks/ListingOptions/bandiInEvidenceTemplate
 msgid "show_ente"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_full_width"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_image_title"
 msgstr ""
 
 #: config/Blocks/ListingOptions/mapTemplate
@@ -1902,6 +1974,7 @@ msgstr ""
 msgid "show_only_first_ribbon"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
@@ -1916,6 +1989,7 @@ msgstr ""
 msgid "show_topics"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_type"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -605,6 +605,74 @@ msgstr ""
 msgid "autoplay_speed_description"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "ay11_Use Up and Down to choose options"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select deselected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select disabled"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select for search term"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select is disabled. Select another option."
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select selected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__press Tab to select the option and exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__type to refine list"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_is_focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Down to open the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Enter to select the currently focused option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Escape to exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press left to focus selected values"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr "indietro"

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -101,6 +101,7 @@ msgstr "Contatti"
 msgid "Content"
 msgstr "Contenuto"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "Content in evidence"
 msgstr "Contenuto in evidenza"
@@ -201,11 +202,15 @@ msgstr "Link ad altro"
 msgid "Link to"
 msgstr "Link a"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr "Link ad altro"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr "Titolo per il link ad altro"
 
@@ -237,6 +242,14 @@ msgstr ""
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
 msgstr "Nessun risultato ottenuto"
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
+msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
 msgid "Next page"
@@ -398,12 +411,14 @@ msgstr "Trascina qui un file per sostituire quello esistente"
 msgid "Twitter Posts"
 msgstr "Twitter Posts"
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr "Digita la descrizione…"
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -412,6 +427,7 @@ msgstr "Digita la descrizione…"
 msgid "Type text…"
 msgstr "Digita testo…"
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -577,6 +593,18 @@ msgstr "Atto di nomina"
 msgid "autenticazione"
 msgstr "Autenticazione"
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed_description"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr "indietro"
@@ -643,6 +671,7 @@ msgid "bando_vedi"
 msgstr "Vedi"
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "bg_color"
 msgstr "Colore di sfondo"
@@ -715,10 +744,12 @@ msgid "closeSearch"
 msgstr "Chiudi ricerca"
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_primary"
 msgstr "Colore primario"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_transparent"
 msgstr "Trasparente"
@@ -757,6 +788,10 @@ msgstr "Contatti esterni"
 #: components/ItaliaTheme/View/EventoView/EventoView
 msgid "contatti_interni"
 msgstr "Contatti interni"
+
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Body
+msgid "content-in-evidence-news"
+msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "copertura_geografica"
@@ -976,7 +1011,9 @@ msgstr "E-mail"
 msgid "email_sede"
 msgstr "E-mail"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Edit
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr "Seleziona un elemento nella barra laterale per mostrarlo qui."
 
@@ -1044,6 +1081,7 @@ msgstr "Esplora"
 msgid "exploreArgument"
 msgstr "Esplora argomento"
 
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderTree
 #: components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar
 msgid "faq_search"
 msgstr "Digita una parola chiave per trovare le risposte"
@@ -1262,10 +1300,16 @@ msgstr "File principale"
 msgid "modulo_formati_alternativi"
 msgstr "Formati alternativi"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "natural_image_size"
 msgstr "Non alterare le dimensioni naturali dell'immagine"
+
+#: components/ItaliaTheme/Blocks/NewsHome/Body
+msgid "newsHome-news"
+msgstr ""
 
 #: components/ItaliaTheme/View/NewsItemView/NewsItemView
 msgid "news_item_contenuto"
@@ -1420,6 +1464,10 @@ msgstr "Testo di aiuto"
 
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 msgid "playStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
@@ -1836,6 +1884,18 @@ msgstr ""
 msgid "select_argument_sidebar"
 msgstr "Seleziona un argomento nella barra a lato"
 
+#: components/SelectInput/SelectInput
+msgid "select_noOptionsMessage"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultati"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultato"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "service_not_active"
 msgstr "Il servizio non è attivo"
@@ -1869,13 +1929,25 @@ msgstr "Mostra la descrizione"
 msgid "show_detail_link"
 msgstr "Mostra il link al dettaglio"
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_dots"
+msgstr ""
+
 #: config/Blocks/ListingOptions/bandiInEvidenceTemplate
 msgid "show_ente"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_full_width"
 msgstr ""
 
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
 msgstr "Mostra l'icona"
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_image_title"
+msgstr ""
 
 #: config/Blocks/ListingOptions/mapTemplate
 msgid "show_map_full_width"
@@ -1885,6 +1957,7 @@ msgstr "Mostra la mappa a tutta larghezza"
 msgid "show_only_first_ribbon"
 msgstr "Mostra il nastro solo sulla prima card"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
@@ -1899,6 +1972,7 @@ msgstr ""
 msgid "show_topics"
 msgstr "Mostra gli argomenti"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_type"

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -612,6 +612,74 @@ msgstr ""
 msgid "autoplay_speed_description"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "ay11_Use Up and Down to choose options"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select deselected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select disabled"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select for search term"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select is disabled. Select another option."
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select selected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__press Tab to select the option and exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__type to refine list"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_is_focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Down to open the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Enter to select the currently focused option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Escape to exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press left to focus selected values"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr ""

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -108,6 +108,7 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "Content in evidence"
 msgstr ""
@@ -208,11 +209,15 @@ msgstr ""
 msgid "Link to"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -243,6 +248,14 @@ msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
 msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
@@ -405,12 +418,14 @@ msgstr ""
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -419,6 +434,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -584,6 +600,18 @@ msgstr ""
 msgid "autenticazione"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed_description"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr ""
@@ -650,6 +678,7 @@ msgid "bando_vedi"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "bg_color"
 msgstr ""
@@ -722,10 +751,12 @@ msgid "closeSearch"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_primary"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_transparent"
 msgstr ""
@@ -763,6 +794,10 @@ msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
 msgid "contatti_interni"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Body
+msgid "content-in-evidence-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioView
@@ -983,7 +1018,9 @@ msgstr ""
 msgid "email_sede"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Edit
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1051,6 +1088,7 @@ msgstr ""
 msgid "exploreArgument"
 msgstr ""
 
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderTree
 #: components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar
 msgid "faq_search"
 msgstr ""
@@ -1269,9 +1307,15 @@ msgstr ""
 msgid "modulo_formati_alternativi"
 msgstr "<<<<<<< HEAD"
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "natural_image_size"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Body
+msgid "newsHome-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/NewsItemView/NewsItemView
@@ -1427,6 +1471,10 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 msgid "playStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
@@ -1843,6 +1891,18 @@ msgstr ""
 msgid "select_argument_sidebar"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "select_noOptionsMessage"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultati"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultato"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "service_not_active"
 msgstr ""
@@ -1876,12 +1936,24 @@ msgstr ""
 msgid "show_detail_link"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_dots"
+msgstr ""
+
 #: config/Blocks/ListingOptions/bandiInEvidenceTemplate
 msgid "show_ente"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_full_width"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_image_title"
 msgstr ""
 
 #: config/Blocks/ListingOptions/mapTemplate
@@ -1892,6 +1964,7 @@ msgstr ""
 msgid "show_only_first_ribbon"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
@@ -1906,6 +1979,7 @@ msgstr ""
 msgid "show_topics"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_type"

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -624,6 +624,74 @@ msgstr ""
 msgid "autoplay_speed_description"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+msgid "ay11_Use Up and Down to choose options"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select deselected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select disabled"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select for search term"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select is disabled. Select another option."
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select selected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__press Tab to select the option and exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select__type to refine list"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_is_focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Down to open the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Enter to select the currently focused option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press Escape to exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "ay11_select_press left to focus selected values"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr ""

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -120,6 +120,7 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "Content in evidence"
 msgstr ""
@@ -220,11 +221,15 @@ msgstr ""
 msgid "Link to"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -255,6 +260,14 @@ msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
 msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
@@ -417,12 +430,14 @@ msgstr ""
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -431,6 +446,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -596,6 +612,18 @@ msgstr ""
 msgid "autenticazione"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "autoplay_speed_description"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 msgid "back"
 msgstr ""
@@ -662,6 +690,7 @@ msgid "bando_vedi"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "bg_color"
 msgstr ""
@@ -734,10 +763,12 @@ msgid "closeSearch"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_primary"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 msgid "color_transparent"
 msgstr ""
@@ -775,6 +806,10 @@ msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
 msgid "contatti_interni"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Body
+msgid "content-in-evidence-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioView
@@ -995,7 +1030,9 @@ msgstr ""
 msgid "email_sede"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Edit
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1063,6 +1100,7 @@ msgstr ""
 msgid "exploreArgument"
 msgstr ""
 
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderTree
 #: components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar
 msgid "faq_search"
 msgstr ""
@@ -1281,9 +1319,15 @@ msgstr ""
 msgid "modulo_formati_alternativi"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "natural_image_size"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Body
+msgid "newsHome-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/NewsItemView/NewsItemView
@@ -1439,6 +1483,10 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 msgid "playStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
@@ -1855,6 +1903,18 @@ msgstr ""
 msgid "select_argument_sidebar"
 msgstr "Seleziona un argomento nella barra a lato"
 
+#: components/SelectInput/SelectInput
+msgid "select_noOptionsMessage"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultati"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+msgid "select_risultato"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 msgid "service_not_active"
 msgstr ""
@@ -1888,12 +1948,24 @@ msgstr ""
 msgid "show_detail_link"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_dots"
+msgstr ""
+
 #: config/Blocks/ListingOptions/bandiInEvidenceTemplate
 msgid "show_ente"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_full_width"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+msgid "show_image_title"
 msgstr ""
 
 #: config/Blocks/ListingOptions/mapTemplate
@@ -1904,6 +1976,7 @@ msgstr ""
 msgid "show_only_first_ribbon"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
@@ -1918,6 +1991,7 @@ msgstr ""
 msgid "show_topics"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 msgid "show_type"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-08-06T07:20:23.535Z\n"
+"POT-Creation-Date: 2021-08-06T09:12:27.930Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -737,6 +737,91 @@ msgstr ""
 #: config/Blocks/ListingOptions/sliderTemplate
 # defaultMessage: La velocità di autoplay deve essere espressa in secondi.
 msgid "autoplay_speed_description"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: Usa le frecce Su e Giu per scegliere un'opzione
+msgid "ay11_Use Up and Down to choose options"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: deselezionata
+msgid "ay11_select deselected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: disabilitato
+msgid "ay11_select disabled"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: evidenziato
+msgid "ay11_select focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: per la ricerca
+msgid "ay11_select for search term"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: è disabilitata. Seleziona un'altra opzione
+msgid "ay11_select is disabled. Select another option."
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: opzione
+msgid "ay11_select option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: selezionata
+msgid "ay11_select selected"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: valore
+msgid "ay11_select value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: Usa le frecce destra e sinistra per attivare o disattivare i valori evidenziati, premi Backspace per rimuovere il valore corrente evidenziato
+msgid "ay11_select_Use left and right to toggle between focused values, press Backspace to remove the currently focused value"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: premi Tab per selezionare l'opzione e uscire dal menu
+msgid "ay11_select__press Tab to select the option and exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: digita per filtrare la lista
+msgid "ay11_select__type to refine list"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: è selezionato
+msgid "ay11_select_is_focused"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: premi freccia giu per aprire il menu, premi Backspace per rimuovere il valore selezionato
+msgid "ay11_select_press Down to open the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: premi Invio per selezionare l'opzione corrente
+msgid "ay11_select_press Enter to select the currently focused option"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: premi Esc per uscire dal menu
+msgid "ay11_select_press Escape to exit the menu"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: premi la freccia a sinistra per evidenziare i valori selezionati
+msgid "ay11_select_press left to focus selected values"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/SideMenu

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2021-08-05T15:41:07.600Z\n"
+"POT-Creation-Date: 2021-08-06T07:20:23.535Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -124,6 +124,7 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Contenuto in primo piano
 msgid "Content in evidence"
@@ -247,12 +248,16 @@ msgstr ""
 msgid "Link to"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 # defaultMessage: Link ad altro
 msgid "LinkMore"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 # defaultMessage: Testo per il link ad altro
 msgid "Linkto title"
 msgstr ""
@@ -290,6 +295,16 @@ msgstr ""
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Nessun risultato ottenuto
 msgid "Nessun risultato ottenuto"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+# defaultMessage: News
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+# defaultMessage: News con immagine in primo piano
+msgid "NewsHome"
 msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
@@ -488,6 +503,7 @@ msgstr ""
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -495,15 +511,17 @@ msgstr ""
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 #: components/ItaliaTheme/manage/Widgets/TextEditorWidget
-# defaultMessage: Digita un testo…
+# defaultMessage: Digita il testo…
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -706,6 +724,21 @@ msgstr ""
 msgid "autenticazione"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+# defaultMessage: Autoplay
+msgid "autoplay"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+# defaultMessage: Velocità autoplay
+msgid "autoplay_speed"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+# defaultMessage: La velocità di autoplay deve essere espressa in secondi.
+msgid "autoplay_speed_description"
+msgstr ""
+
 #: components/ItaliaTheme/View/Commons/SideMenu
 # defaultMessage: Indietro
 msgid "back"
@@ -787,6 +820,7 @@ msgid "bando_vedi"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Colore di sfondo
 msgid "bg_color"
@@ -876,11 +910,13 @@ msgid "closeSearch"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/ContactsBlock/Sidebar
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Primario
 msgid "color_primary"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 # defaultMessage: Trasparente
 msgid "color_transparent"
@@ -927,6 +963,11 @@ msgstr ""
 #: components/ItaliaTheme/View/EventoView/EventoView
 # defaultMessage: Contatti interni
 msgid "contatti_interni"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Body
+# defaultMessage: News
+msgid "content-in-evidence-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioView
@@ -1198,7 +1239,9 @@ msgstr ""
 msgid "email_sede"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Edit
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 # defaultMessage: Please select an item in the sidebar in order to show it here
 msgid "emptySelection"
 msgstr ""
@@ -1283,6 +1326,7 @@ msgstr ""
 msgid "exploreArgument"
 msgstr ""
 
+#: components/ItaliaTheme/View/FAQ/FaqFolder/FaqFolderTree
 #: components/ItaliaTheme/View/FAQ/FaqFolder/SearchBar
 # defaultMessage: Type in a keyword to find answers
 msgid "faq_search"
@@ -1551,10 +1595,17 @@ msgstr ""
 msgid "modulo_formati_alternativi"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: undefined
 msgid "natural_image_size"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Body
+# defaultMessage: undefined
+msgid "newsHome-news"
 msgstr ""
 
 #: components/ItaliaTheme/View/NewsItemView/NewsItemView
@@ -1746,6 +1797,11 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
 # defaultMessage: PlayStore Link
 msgid "playStoreLink"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+# defaultMessage: A PORTATA DI CLICK
+msgid "portata_di_click"
 msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
@@ -2256,6 +2312,21 @@ msgstr ""
 msgid "select_argument_sidebar"
 msgstr ""
 
+#: components/SelectInput/SelectInput
+# defaultMessage: Nessuna opzione
+msgid "select_noOptionsMessage"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: risultati
+msgid "select_risultati"
+msgstr ""
+
+#: components/SelectInput/SelectInput
+# defaultMessage: risultato
+msgid "select_risultato"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioView
 # defaultMessage: Il servizio non è attivo
 msgid "service_not_active"
@@ -2297,14 +2368,29 @@ msgstr ""
 msgid "show_detail_link"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+# defaultMessage: Mostra i puntini di scorrimento
+msgid "show_dots"
+msgstr ""
+
 #: config/Blocks/ListingOptions/bandiInEvidenceTemplate
 # defaultMessage: Mostra l'ente
 msgid "show_ente"
 msgstr ""
 
+#: config/Blocks/ListingOptions/sliderTemplate
+# defaultMessage: A tutta larghezza
+msgid "show_full_width"
+msgstr ""
+
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra l'icona
 msgid "show_icon"
+msgstr ""
+
+#: config/Blocks/ListingOptions/sliderTemplate
+# defaultMessage: Mostra il titolo dell'immagine
+msgid "show_image_title"
 msgstr ""
 
 #: config/Blocks/ListingOptions/mapTemplate
@@ -2317,6 +2403,7 @@ msgstr ""
 msgid "show_only_first_ribbon"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra la sezione
@@ -2334,6 +2421,7 @@ msgstr ""
 msgid "show_topics"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ContentInEvidence/Sidebar
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra il tipo

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -107,7 +107,11 @@ const SliderTemplate = ({
   //const getCaption = (item) => item.description ?? item.rights ?? null;
 
   return (
-    <div className={`sliderTemplate slidesToShow-${nSlidesToShow || 1}`}>
+    <div
+      className={cx(`sliderTemplate slidesToShow-${nSlidesToShow || 1}`, {
+        'no-margin': full_width,
+      })}
+    >
       <Container className="px-4">
         {title && (
           <Row>

--- a/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SliderTemplate.jsx
@@ -3,6 +3,7 @@
 /* eslint-disable jsx-a11y/interactive-supports-focus */
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import { useIntl, defineMessages } from 'react-intl';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import Slider from 'react-slick';
@@ -35,19 +36,24 @@ const SliderTemplate = ({
   linkTitle,
   linkHref,
   slidesToShow = '1',
+  full_width = false,
+  show_image_title = true,
+  show_dots = true,
+  autoplay = false,
+  autoplay_speed = 2, //seconds
 }) => {
   const intl = useIntl();
   const slider = useRef(null);
-  const [autoplay, setAutoplay] = useState(false);
+  const [userAutoplay, setUserAutoplay] = useState(autoplay);
   const nSlidesToShow = parseInt(slidesToShow);
 
   const toggleAutoplay = () => {
     if (!slider?.current) return;
-    if (autoplay) {
-      setAutoplay(false);
+    if (userAutoplay) {
+      setUserAutoplay(false);
       slider.current.slickPause();
     } else {
-      setAutoplay(true);
+      setUserAutoplay(true);
       slider.current.slickPlay();
     }
   };
@@ -71,12 +77,13 @@ const SliderTemplate = ({
   };
 
   const settings = {
-    dots: true,
+    dots: show_dots,
     infinite: true,
+    autoplay: autoplay,
     speed: 500,
     slidesToShow: nSlidesToShow,
     slidesToScroll: nSlidesToShow,
-    autoplaySpeed: 2000,
+    autoplaySpeed: autoplay_speed * 1000,
     pauseOnHover: true,
     pauseOnFocus: true,
     pauseOnDotsHover: true,
@@ -109,20 +116,25 @@ const SliderTemplate = ({
             </Col>
           </Row>
         )}
-        <div className="slider-container px-4 px-md-0">
+        <div
+          className={cx('slider-container', {
+            'px-4 px-md-0': !full_width,
+            'full-width': full_width,
+          })}
+        >
           <div className="it-carousel-all it-card-bg">
             {items?.length > nSlidesToShow && (
               <div className="play-pause-wrapper">
                 <button
                   onClick={() => toggleAutoplay()}
                   title={
-                    autoplay
+                    userAutoplay
                       ? intl.formatMessage(messages.pause)
                       : intl.formatMessage(messages.play)
                   }
                 >
-                  <Icon icon={autoplay ? 'pause' : 'play'} />
-                  <span>{autoplay ? 'pause' : 'play'}</span>
+                  <Icon icon={userAutoplay ? 'pause' : 'play'} />
+                  <span>{userAutoplay ? 'pause' : 'play'}</span>
                 </button>
               </div>
             )}
@@ -153,14 +165,16 @@ const SliderTemplate = ({
                         <figcaption>{getCaption(item)}</figcaption>
                       )} */}
                       </figure>
-                      <UniversalLink
-                        item={item}
-                        title={intl.formatMessage(messages.viewImage)}
-                      >
-                        <div className="slide-title">
-                          {item.title} <Icon icon="arrow-right" />
-                        </div>
-                      </UniversalLink>
+                      {show_image_title && (
+                        <UniversalLink
+                          item={item}
+                          title={intl.formatMessage(messages.viewImage)}
+                        >
+                          <div className="slide-title">
+                            {item.title} <Icon icon="arrow-right" />
+                          </div>
+                        </UniversalLink>
+                      )}
                     </div>
                   </div>
                 );

--- a/src/config/Blocks/ListingOptions/sliderTemplate.js
+++ b/src/config/Blocks/ListingOptions/sliderTemplate.js
@@ -3,9 +3,33 @@ import { defineMessages } from 'react-intl';
 import { addSchemaField } from '@italia/config/Blocks/ListingOptions';
 
 const messages = defineMessages({
+  show_full_width: {
+    id: 'show_full_width',
+    defaultMessage: 'A tutta larghezza',
+  },
   slidesToShow: {
     id: 'slidesToShow',
     defaultMessage: 'N° slide da mostrare',
+  },
+  show_image_title: {
+    id: 'show_image_title',
+    defaultMessage: "Mostra il titolo dell'immagine",
+  },
+  show_dots: {
+    id: 'show_dots',
+    defaultMessage: 'Mostra i puntini di scorrimento',
+  },
+  autoplay: {
+    id: 'autoplay',
+    defaultMessage: 'Autoplay',
+  },
+  autoplay_speed: {
+    id: 'autoplay_speed',
+    defaultMessage: 'Velocità autoplay',
+  },
+  autoplay_speed_description: {
+    id: 'autoplay_speed_description',
+    defaultMessage: 'La velocità di autoplay deve essere espressa in secondi.',
   },
 });
 
@@ -16,6 +40,56 @@ export const addSliderTemplateOptions = (
   position = 0,
 ) => {
   let pos = position;
+
+  addSchemaField(
+    schema,
+    'full_width',
+    intl.formatMessage(messages.show_full_width),
+    null,
+    { type: 'boolean' },
+    pos,
+  );
+  pos++;
+
+  addSchemaField(
+    schema,
+    'show_image_title',
+    intl.formatMessage(messages.show_image_title),
+    null,
+    { type: 'boolean', default: true },
+    pos,
+  );
+  pos++;
+
+  addSchemaField(
+    schema,
+    'show_dots',
+    intl.formatMessage(messages.show_dots),
+    null,
+    { type: 'boolean', default: true },
+    pos,
+  );
+  pos++;
+
+  addSchemaField(
+    schema,
+    'autoplay',
+    intl.formatMessage(messages.autoplay),
+    null,
+    { type: 'boolean', default: false },
+    pos,
+  );
+  pos++;
+
+  addSchemaField(
+    schema,
+    'autoplay_speed',
+    intl.formatMessage(messages.autoplay_speed),
+    intl.formatMessage(messages.autoplay_speed_description),
+    { type: 'number', default: 2 },
+    pos,
+  );
+  pos++;
 
   pos = addSchemaField(
     schema,

--- a/theme/ItaliaTheme/Blocks/_sliderTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_sliderTemplate.scss
@@ -177,6 +177,11 @@
     }
   }
 
+  &.no-margin {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
   .slider-container.full-width {
     .slick-arrow.slick-prev {
       z-index: 1;

--- a/theme/ItaliaTheme/Blocks/_sliderTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_sliderTemplate.scss
@@ -177,6 +177,18 @@
     }
   }
 
+  .slider-container.full-width {
+    .slick-arrow.slick-prev {
+      z-index: 1;
+      left: 1rem;
+    }
+
+    .slick-arrow.slick-next {
+      z-index: 1;
+      right: 1rem;
+    }
+  }
+
   @media (max-width: #{map-get($grid-breakpoints, sm)}) {
     .slider-container {
       .it-carousel-all {


### PR DESCRIPTION
Ora nel template Slider del blocco elenco, ci sono queste nuove funzionalità con i seguenti valori di default:
<img width="378" alt="Schermata 2021-08-06 alle 09 22 00" src="https://user-images.githubusercontent.com/51911425/128472582-4864b561-a5d9-4094-9143-0173fd993665.png">
I valori impostati di default non alterano gli slider esistenti