### PR TITLE
Fix allo stile del bottone del blocco searchSections

### DIFF
--- a/theme/ItaliaTheme/Blocks/_searchSections.scss
+++ b/theme/ItaliaTheme/Blocks/_searchSections.scss
@@ -1,7 +1,7 @@
 .container .block {
   height: auto;
 
-  .searchSections {
+  .searchSections:not(.button) {
     width: 100%;
     height: auto;
     min-height: 280px;


### PR DESCRIPTION
Il bottone di searchSections nel block chooser aveva gli stili dell'intero blocco applicati, quindi era altissimo.