### PR TITLE
fix: bugfix content folder

### DIFF
--- a/theme/_cms-ui.scss
+++ b/theme/_cms-ui.scss
@@ -498,7 +498,7 @@ body.cms-ui {
       width: 90% !important;
     }
 
-    table.ui.single.line {
+    table.ui.single.line tbody {
       white-space: normal;
       word-break: break-word;
     }


### PR DESCRIPTION
I titoli della folder content andavano a capo anche nella thead, l'ho specificato solo per il tbody