### PR TITLE
fix: fixed WideImage on route change

### DIFF
--- a/src/components/ItaliaTheme/View/Commons/WideImage.jsx
+++ b/src/components/ItaliaTheme/View/Commons/WideImage.jsx
@@ -21,6 +21,7 @@ const WideImage = ({ image, title, caption, fullWidth = true }) => {
             title={caption || title}
             critical
             loading="eager"
+            key={image?.download}
           />
         )}
         {caption && (


### PR DESCRIPTION
Fissato un bug nelle immagini in testata, per cui se si andava da un contenuto ad un altro cliccando su un link presente in pagina, l'immagine in testata non veniva aggiornata e continuava a vedersi l'immagine in testata del contenuto precedente.