### PR TITLE
fix: fixed topics in search

### DIFF
--- a/src/components/ItaliaTheme/Search/utils.js
+++ b/src/components/ItaliaTheme/Search/utils.js
@@ -95,7 +95,7 @@ const parseFetchedTopics = (topics, location) => {
   const qsTopics = qs.parse(location?.search ?? '')?.tassonomia_argomenti ?? [];
 
   return topics.reduce((acc, topic) => {
-    acc[topic.path] = {
+    acc[flattenToAppURL(topic['@id'])] = {
       value: qsTopics.indexOf(topic.title) > -1,
       label: topic.title,
     };


### PR DESCRIPTION
C'era un problema negli argomenti della ricerca, sia nella popup di ricerca, sia nella sidebar laterale della pagina dei risultati, non venivano mostrati correttamente perchè dal BE non arrivava più il campo 'path' (probabilmente da quando è stata tolta la fullobjects?). 
