### PR TITLE
fix: 4th element now shows image in CardWithImageTemplate with 4 columns

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -38,6 +38,10 @@ msgstr ""
 msgid "Add accordion item"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "Add field"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
 msgid "Alert"
 msgstr ""
@@ -46,6 +50,7 @@ msgstr ""
 msgid "Allow Externals"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "Aspetto"
 msgstr ""
@@ -70,6 +75,7 @@ msgstr ""
 msgid "Card detail label"
 msgstr ""
 
+#: components/ItaliaTheme/Header/HeaderCenter
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 msgid "Cerca"
 msgstr ""
@@ -87,6 +93,7 @@ msgstr ""
 msgid "Cerca per parola chiave"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Clicca qui per sostituire il file"
 msgstr ""
@@ -154,10 +161,23 @@ msgstr ""
 msgid "Dimensione della mappa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email Success"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email sent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Error"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Etichetta location filter"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Etichetta path filter"
@@ -169,6 +189,10 @@ msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Filtro location filter"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "Form"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/SkipToMainContent
@@ -229,10 +253,12 @@ msgid "Link to"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -250,6 +276,7 @@ msgstr ""
 msgid "Mostra i filtri per luogo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra i filtri per percorso"
@@ -257,6 +284,9 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra lo sfondo del blocco"
@@ -268,6 +298,14 @@ msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
 msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
@@ -290,6 +328,7 @@ msgstr ""
 msgid "Open in a new tab"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Path filter filtro"
@@ -300,6 +339,7 @@ msgstr ""
 msgid "Pause slider"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Percorso path filter"
@@ -319,6 +359,7 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Rimuovi il file"
 msgstr ""
@@ -347,6 +388,7 @@ msgstr ""
 msgid "SearchServicesTitle"
 msgstr ""
 
+#: components/ItaliaTheme/Footer/FooterSocials
 #: components/ItaliaTheme/Header/SocialHeader
 msgid "Seguici su"
 msgstr ""
@@ -359,6 +401,7 @@ msgstr ""
 msgid "Select all or none"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Seleziona un file"
 msgstr ""
@@ -395,6 +438,7 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Text placeholder"
 msgstr ""
@@ -412,24 +456,32 @@ msgid "Title"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Body
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Title placeholder"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "Titolo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui il file ..."
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per caricare un nuovo file"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per sostituire quello esistente"
 msgstr ""
@@ -438,12 +490,15 @@ msgstr ""
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Accordion/TextEditorWidget
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -452,6 +507,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -481,6 +537,7 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
@@ -493,7 +550,10 @@ msgstr ""
 msgid "Vedi l'immagine"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate
 #: components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore
+#: components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate
+#: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 #: components/ItaliaTheme/MegaMenu/MegaMenu
@@ -533,14 +593,17 @@ msgid "advandedSectionsFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allOptions"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allTopics"
 msgstr ""
 
@@ -560,10 +623,12 @@ msgstr ""
 msgid "altri_documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "always_show_image"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "amministrazione"
 msgstr ""
@@ -710,6 +775,7 @@ msgid "back"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "backToSearch"
 msgstr ""
 
@@ -779,6 +845,7 @@ msgstr ""
 msgid "biografia"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/BgColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "block_bg_color"
 msgstr ""
@@ -860,6 +927,7 @@ msgid "close"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "closeSearch"
 msgstr ""
 
@@ -883,6 +951,10 @@ msgstr ""
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 #: components/ItaliaTheme/View/UOView/UOView
 msgid "competenze"
+msgstr ""
+
+#: components/ItaliaTheme/Header/SearchModal
+msgid "confirmSearch"
 msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
@@ -1158,6 +1230,8 @@ msgstr ""
 msgid "deselectSearchSection"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "detail_link_label"
 msgstr ""
@@ -1180,10 +1254,12 @@ msgstr ""
 msgid "dirigente"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "documenti-e-dati"
 msgstr ""
@@ -1262,6 +1338,7 @@ msgid "email_sede"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1285,9 +1362,17 @@ msgstr ""
 msgid "event_documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_endDate"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/EventSearch/Edit
 #: components/ItaliaTheme/Blocks/UOSearch/Edit
 msgid "event_search_no_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_startDate"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
@@ -1348,6 +1433,7 @@ msgid "file_correlato"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "filters"
 msgstr ""
 
@@ -1364,6 +1450,107 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 msgid "fine_termine"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_subject"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_default_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_empty_values_validation"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_input_values"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_required"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_attachment"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_checkbox"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_date"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_radio"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_select"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_text"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_textarea"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Field
+msgid "form_select_a_value"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_to"
 msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
@@ -1416,6 +1603,9 @@ msgstr ""
 msgid "grid-gallery-max-items-exceeded"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "hide_dates"
 msgstr ""
@@ -1491,6 +1681,7 @@ msgstr ""
 msgid "listing_event_recurrence_label"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/ItemsColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "listing_items_color"
 msgstr ""
@@ -1630,6 +1821,7 @@ msgstr ""
 msgid "notizie_in_evidenza"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "novita"
 msgstr ""
@@ -1643,42 +1835,51 @@ msgid "openLinkInNewTab"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionActiveContentButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentInfo"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentLabel"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateEnd"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateEndButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDatePlaceholder"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateStart"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateStartButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "options"
 msgstr ""
@@ -1753,6 +1954,10 @@ msgstr ""
 msgid "playStoreLink"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
 msgid "previewIconSelected"
 msgstr ""
@@ -1811,11 +2016,13 @@ msgid "related_uo"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "removeOption"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "removeTopic"
 msgstr ""
 
@@ -1935,6 +2142,7 @@ msgid "scrivi_a_mail"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/SearchSectionForm
 msgid "search"
@@ -2082,6 +2290,7 @@ msgid "searchInSection"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "searchLabel"
 msgstr ""
 
@@ -2170,6 +2379,7 @@ msgid "section_undefined"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "sections"
 msgstr ""
@@ -2206,6 +2416,7 @@ msgstr ""
 msgid "service_not_active"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "servizi"
 msgstr ""
@@ -2231,10 +2442,13 @@ msgstr ""
 msgid "share"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_description"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_detail_link"
 msgstr ""
@@ -2251,6 +2465,7 @@ msgstr ""
 msgid "show_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
 msgstr ""
@@ -2267,6 +2482,7 @@ msgstr ""
 msgid "show_map_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 msgid "show_only_first_ribbon"
 msgstr ""
@@ -2276,6 +2492,7 @@ msgid "show_pointer_list"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
 msgstr ""
@@ -2299,10 +2516,12 @@ msgstr ""
 msgid "silenzio_assenso"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_compact"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_description"
 msgstr ""
@@ -2408,6 +2627,7 @@ msgid "termini_del_procedimento"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/TextFilter
 msgid "text_filter_placeholder"
 msgstr ""
 
@@ -2445,6 +2665,7 @@ msgid "to"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti
 msgid "topics"
@@ -2495,6 +2716,7 @@ msgid "unita_organizzativa_competente"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/RenderBlocks
+#: components/ItaliaTheme/View/Commons/TextOrBlocks
 msgid "unknownBlock"
 msgstr ""
 

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -23,6 +23,10 @@ msgstr "Login to your personal area"
 msgid "Add accordion item"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "Add field"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
 msgid "Alert"
 msgstr ""
@@ -31,6 +35,7 @@ msgstr ""
 msgid "Allow Externals"
 msgstr "Accept external URL to embed"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "Aspetto"
 msgstr ""
@@ -55,6 +60,7 @@ msgstr ""
 msgid "Card detail label"
 msgstr "Show"
 
+#: components/ItaliaTheme/Header/HeaderCenter
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 msgid "Cerca"
 msgstr "Search"
@@ -72,6 +78,7 @@ msgstr "Search by topic"
 msgid "Cerca per parola chiave"
 msgstr "Search by keyword"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Clicca qui per sostituire il file"
 msgstr "Click here to replace file"
@@ -139,10 +146,23 @@ msgstr ""
 msgid "Dimensione della mappa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email Success"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email sent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Error"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Etichetta location filter"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Etichetta path filter"
@@ -154,6 +174,10 @@ msgstr "No answers found for your question"
 
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Filtro location filter"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "Form"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/SkipToMainContent
@@ -214,10 +238,12 @@ msgid "Link to"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -235,6 +261,7 @@ msgstr "Menu selected"
 msgid "Mostra i filtri per luogo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra i filtri per percorso"
@@ -242,6 +269,9 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra lo sfondo del blocco"
@@ -254,6 +284,14 @@ msgstr "Show all topics"
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
 msgstr "No results found"
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
+msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
 msgid "Next page"
@@ -275,6 +313,7 @@ msgstr ""
 msgid "Open in a new tab"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Path filter filtro"
@@ -285,6 +324,7 @@ msgstr ""
 msgid "Pause slider"
 msgstr "Pause"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Percorso path filter"
@@ -304,6 +344,7 @@ msgstr "Previous page"
 msgid "Required"
 msgstr "Required"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Rimuovi il file"
 msgstr "Remove file"
@@ -332,6 +373,7 @@ msgstr ""
 msgid "SearchServicesTitle"
 msgstr ""
 
+#: components/ItaliaTheme/Footer/FooterSocials
 #: components/ItaliaTheme/Header/SocialHeader
 msgid "Seguici su"
 msgstr "Follow us on"
@@ -344,6 +386,7 @@ msgstr "Select all content types or none"
 msgid "Select all or none"
 msgstr "Select all or none"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Seleziona un file"
 msgstr ""
@@ -380,6 +423,7 @@ msgstr "Subscribe"
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Text placeholder"
 msgstr ""
@@ -397,24 +441,32 @@ msgid "Title"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Body
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Title placeholder"
 msgstr "Title..."
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "Titolo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui il file ..."
 msgstr "Drop the file here ..."
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per caricare un nuovo file"
 msgstr "Drop the file here to upload a new file"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per sostituire quello esistente"
 msgstr "Drop the file here to replace existing file"
@@ -423,12 +475,15 @@ msgstr "Drop the file here to replace existing file"
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Accordion/TextEditorWidget
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -437,6 +492,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -466,6 +522,7 @@ msgstr "Go to page"
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
@@ -478,7 +535,10 @@ msgstr "View"
 msgid "Vedi l'immagine"
 msgstr "View image"
 
+#: components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate
 #: components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore
+#: components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate
+#: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 #: components/ItaliaTheme/MegaMenu/MegaMenu
@@ -518,14 +578,17 @@ msgid "advandedSectionsFilters"
 msgstr "Go to advanced search by sections"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allFilters"
 msgstr "All"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allOptions"
 msgstr "All options"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allTopics"
 msgstr "All topics"
 
@@ -545,10 +608,12 @@ msgstr ""
 msgid "altri_documenti"
 msgstr "Other documents"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "always_show_image"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "amministrazione"
 msgstr "Government"
@@ -695,6 +760,7 @@ msgid "back"
 msgstr "back"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "backToSearch"
 msgstr "Back to search"
 
@@ -764,6 +830,7 @@ msgstr ""
 msgid "biografia"
 msgstr "Biography"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/BgColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "block_bg_color"
 msgstr ""
@@ -845,6 +912,7 @@ msgid "close"
 msgstr "close"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "closeSearch"
 msgstr "Close search"
 
@@ -869,6 +937,10 @@ msgstr "Remunerations"
 #: components/ItaliaTheme/View/UOView/UOView
 msgid "competenze"
 msgstr "Skills"
+
+#: components/ItaliaTheme/Header/SearchModal
+msgid "confirmSearch"
+msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "contacts"
@@ -1143,6 +1215,8 @@ msgstr "Extended description"
 msgid "deselectSearchSection"
 msgstr "Do not search in section"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "detail_link_label"
 msgstr ""
@@ -1165,10 +1239,12 @@ msgstr "Tax declaration"
 msgid "dirigente"
 msgstr "Manager"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "documenti"
 msgstr "Documents"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "documenti-e-dati"
 msgstr "Documents and data"
@@ -1247,6 +1323,7 @@ msgid "email_sede"
 msgstr "E-mail"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1270,9 +1347,17 @@ msgstr "The event is of interest to"
 msgid "event_documenti"
 msgstr "Documents"
 
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_endDate"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/EventSearch/Edit
 #: components/ItaliaTheme/Blocks/UOSearch/Edit
 msgid "event_search_no_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_startDate"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
@@ -1333,6 +1418,7 @@ msgid "file_correlato"
 msgstr "Related file"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "filters"
 msgstr "Filters"
 
@@ -1350,6 +1436,107 @@ msgstr "Search"
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 msgid "fine_termine"
 msgstr "End of term"
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_subject"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_default_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_empty_values_validation"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_input_values"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_required"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_attachment"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_checkbox"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_date"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_radio"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_select"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_text"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_textarea"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Field
+msgid "form_select_a_value"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_to"
+msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "foto_attivita_politica"
@@ -1401,6 +1588,9 @@ msgstr "View previous image"
 msgid "grid-gallery-max-items-exceeded"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "hide_dates"
 msgstr ""
@@ -1476,6 +1666,7 @@ msgstr "Useful links"
 msgid "listing_event_recurrence_label"
 msgstr "This event has multiple dates: see all"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/ItemsColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "listing_items_color"
 msgstr ""
@@ -1615,6 +1806,7 @@ msgstr "nominative"
 msgid "notizie_in_evidenza"
 msgstr "News in evidence"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "novita"
 msgstr "News"
@@ -1628,42 +1820,51 @@ msgid "openLinkInNewTab"
 msgstr "Open link in a new tab"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionActiveContentButton"
 msgstr "Active content"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentInfo"
 msgstr "Archived and no longer valid contents, such as finished events or expired calls, will be excluded from the search."
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentLabel"
 msgstr "Search only active content"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateEnd"
 msgstr "End date"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateEndButton"
 msgstr "To"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDatePlaceholder"
 msgstr "insert date in format dd/mm/yyyy"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateStart"
 msgstr "Start date"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateStartButton"
 msgstr "From"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "options"
 msgstr "Options"
@@ -1738,6 +1939,10 @@ msgstr ""
 msgid "playStoreLink"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
 msgid "previewIconSelected"
 msgstr ""
@@ -1796,11 +2001,13 @@ msgid "related_uo"
 msgstr "Government"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "removeOption"
 msgstr "Remove option"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "removeTopic"
 msgstr "Remove topic"
 
@@ -1920,6 +2127,7 @@ msgid "scrivi_a_mail"
 msgstr "Write to"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/SearchSectionForm
 msgid "search"
@@ -2067,6 +2275,7 @@ msgid "searchInSection"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "searchLabel"
 msgstr "Search site"
 
@@ -2155,6 +2364,7 @@ msgid "section_undefined"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "sections"
 msgstr "Sections"
@@ -2191,6 +2401,7 @@ msgstr ""
 msgid "service_not_active"
 msgstr "The service is not active"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "servizi"
 msgstr "Services"
@@ -2216,10 +2427,13 @@ msgstr "Arrange on 4 columns"
 msgid "share"
 msgstr "Share"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_description"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_detail_link"
 msgstr ""
@@ -2236,6 +2450,7 @@ msgstr ""
 msgid "show_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
 msgstr ""
@@ -2252,6 +2467,7 @@ msgstr ""
 msgid "show_map_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 msgid "show_only_first_ribbon"
 msgstr ""
@@ -2261,6 +2477,7 @@ msgid "show_pointer_list"
 msgstr "Show bulleted list"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
 msgstr ""
@@ -2284,10 +2501,12 @@ msgstr ""
 msgid "silenzio_assenso"
 msgstr "Silence assent"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_compact"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_description"
 msgstr ""
@@ -2393,6 +2612,7 @@ msgid "termini_del_procedimento"
 msgstr "Terms of the procedure"
 
 #: components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/TextFilter
 msgid "text_filter_placeholder"
 msgstr "Insert a value"
 
@@ -2430,6 +2650,7 @@ msgid "to"
 msgstr "to"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti
 msgid "topics"
@@ -2480,6 +2701,7 @@ msgid "unita_organizzativa_competente"
 msgstr "Competent organizational unit for the procedure"
 
 #: components/ItaliaTheme/View/Commons/RenderBlocks
+#: components/ItaliaTheme/View/Commons/TextOrBlocks
 msgid "unknownBlock"
 msgstr "Unknown block"
 

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -40,6 +40,10 @@ msgstr "Accéder à l'espace personnel"
 msgid "Add accordion item"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "Add field"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
 msgid "Alert"
 msgstr "Alerte"
@@ -48,6 +52,7 @@ msgstr "Alerte"
 msgid "Allow Externals"
 msgstr "Accepter les URL externes pour l'intégration"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "Aspetto"
 msgstr ""
@@ -72,6 +77,7 @@ msgstr ""
 msgid "Card detail label"
 msgstr "Voir"
 
+#: components/ItaliaTheme/Header/HeaderCenter
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 msgid "Cerca"
 msgstr "Rechercher"
@@ -89,6 +95,7 @@ msgstr "Recherche par sujet"
 msgid "Cerca per parola chiave"
 msgstr "Recherche par mots-clés"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Clicca qui per sostituire il file"
 msgstr "Cliquez ici pour remplacer le fichier"
@@ -156,10 +163,23 @@ msgstr ""
 msgid "Dimensione della mappa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email Success"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email sent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Error"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Etichetta location filter"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Etichetta path filter"
@@ -171,6 +191,10 @@ msgstr "Aucun résultat obtenu"
 
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Filtro location filter"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "Form"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/SkipToMainContent
@@ -231,10 +255,12 @@ msgid "Link to"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -252,6 +278,7 @@ msgstr "Menu sélectionné"
 msgid "Mostra i filtri per luogo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra i filtri per percorso"
@@ -259,6 +286,9 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra lo sfondo del blocco"
@@ -271,6 +301,14 @@ msgstr "Afficher tous les sujets"
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
 msgstr "Aucun résultat obtenu"
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
+msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
 msgid "Next page"
@@ -292,6 +330,7 @@ msgstr ""
 msgid "Open in a new tab"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Path filter filtro"
@@ -302,6 +341,7 @@ msgstr ""
 msgid "Pause slider"
 msgstr "Pause"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Percorso path filter"
@@ -321,6 +361,7 @@ msgstr "Page précédente"
 msgid "Required"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Rimuovi il file"
 msgstr "Supprimer le fichier"
@@ -349,6 +390,7 @@ msgstr ""
 msgid "SearchServicesTitle"
 msgstr ""
 
+#: components/ItaliaTheme/Footer/FooterSocials
 #: components/ItaliaTheme/Header/SocialHeader
 msgid "Seguici su"
 msgstr "Suivez-nous sur"
@@ -361,6 +403,7 @@ msgstr "Sélectionner tous les types de contenu ou aucun"
 msgid "Select all or none"
 msgstr "Sélectionner tout ou aucun"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Seleziona un file"
 msgstr "Sélectionner un fichier"
@@ -397,6 +440,7 @@ msgstr "S'abonner"
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Text placeholder"
 msgstr ""
@@ -414,24 +458,32 @@ msgid "Title"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Body
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Title placeholder"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "Titolo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui il file ..."
 msgstr "Déposez le fichier ici ..."
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per caricare un nuovo file"
 msgstr "Déposez un fichier ici pour télécharger un nouveau fichier"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per sostituire quello esistente"
 msgstr "Faites glisser un fichier ici pour remplacer l'existant"
@@ -440,12 +492,15 @@ msgstr "Faites glisser un fichier ici pour remplacer l'existant"
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Accordion/TextEditorWidget
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -454,6 +509,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -483,6 +539,7 @@ msgstr "Aller à la page"
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
@@ -495,7 +552,10 @@ msgstr "Voyez"
 msgid "Vedi l'immagine"
 msgstr "Regarder la photo"
 
+#: components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate
 #: components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore
+#: components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate
+#: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 #: components/ItaliaTheme/MegaMenu/MegaMenu
@@ -535,14 +595,17 @@ msgid "advandedSectionsFilters"
 msgstr "Aller à la recherche avancée par rubrique"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allFilters"
 msgstr "Tout"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allOptions"
 msgstr "Toutes les options"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allTopics"
 msgstr "Tous les sujets"
 
@@ -562,10 +625,12 @@ msgstr ""
 msgid "altri_documenti"
 msgstr "Autres documents"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "always_show_image"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "amministrazione"
 msgstr "Administration"
@@ -712,6 +777,7 @@ msgid "back"
 msgstr "retourner"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "backToSearch"
 msgstr "Retour à la recherche"
 
@@ -781,6 +847,7 @@ msgstr ""
 msgid "biografia"
 msgstr "Biographie"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/BgColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "block_bg_color"
 msgstr ""
@@ -862,6 +929,7 @@ msgid "close"
 msgstr "Fermer"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "closeSearch"
 msgstr "Fermer la recherche"
 
@@ -886,6 +954,10 @@ msgstr "Compensations"
 #: components/ItaliaTheme/View/UOView/UOView
 msgid "competenze"
 msgstr "Compétences"
+
+#: components/ItaliaTheme/Header/SearchModal
+msgid "confirmSearch"
+msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "contacts"
@@ -1160,6 +1232,8 @@ msgstr "Description détaillée"
 msgid "deselectSearchSection"
 msgstr "Ne pas chercher dans les sections"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "detail_link_label"
 msgstr ""
@@ -1182,10 +1256,12 @@ msgstr "Déclaration d'impôts"
 msgid "dirigente"
 msgstr "Directeur"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "documenti"
 msgstr "Documents"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "documenti-e-dati"
 msgstr "Documents et données"
@@ -1264,6 +1340,7 @@ msgid "email_sede"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1287,9 +1364,17 @@ msgstr "Destinataires"
 msgid "event_documenti"
 msgstr "Documents"
 
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_endDate"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/EventSearch/Edit
 #: components/ItaliaTheme/Blocks/UOSearch/Edit
 msgid "event_search_no_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_startDate"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
@@ -1350,6 +1435,7 @@ msgid "file_correlato"
 msgstr "Dossier connexe"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "filters"
 msgstr "Filtres"
 
@@ -1367,6 +1453,107 @@ msgstr "Rechercher"
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 msgid "fine_termine"
 msgstr "Fin du mandat"
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_subject"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_default_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_empty_values_validation"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_input_values"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_required"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_attachment"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_checkbox"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_date"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_radio"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_select"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_text"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_textarea"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Field
+msgid "form_select_a_value"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_to"
+msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "foto_attivita_politica"
@@ -1418,6 +1605,9 @@ msgstr "Voir l'image précédente"
 msgid "grid-gallery-max-items-exceeded"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "hide_dates"
 msgstr ""
@@ -1493,6 +1683,7 @@ msgstr "Liens utiles"
 msgid "listing_event_recurrence_label"
 msgstr "Cet événement a plusieurs dates: tout voir"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/ItemsColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "listing_items_color"
 msgstr ""
@@ -1632,6 +1823,7 @@ msgstr "nominatif"
 msgid "notizie_in_evidenza"
 msgstr "Nouvelles en vedette"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "novita"
 msgstr "Annonces"
@@ -1645,42 +1837,51 @@ msgid "openLinkInNewTab"
 msgstr "Ouvrir le lien dans un nouvel onglet"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionActiveContentButton"
 msgstr "Contenu actif"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentInfo"
 msgstr "Les contenus archivés et non valides tels que les événements terminés ou les appels expirés seront exclus de la recherche."
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentLabel"
 msgstr "Rechercher uniquement le contenu actif"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateEnd"
 msgstr "Date de fin"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateEndButton"
 msgstr "au"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDatePlaceholder"
 msgstr "entrez la date au format jj/mm/aaaa"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateStart"
 msgstr "Date de début"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateStartButton"
 msgstr "Du"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "options"
 msgstr "Options"
@@ -1755,6 +1956,10 @@ msgstr ""
 msgid "playStoreLink"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
 msgid "previewIconSelected"
 msgstr ""
@@ -1813,11 +2018,13 @@ msgid "related_uo"
 msgstr "Administration"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "removeOption"
 msgstr "Supprimer l'option"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "removeTopic"
 msgstr "Supprimer le sujet"
 
@@ -1937,6 +2144,7 @@ msgid "scrivi_a_mail"
 msgstr "Ecrire à l'adresse"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/SearchSectionForm
 msgid "search"
@@ -2084,6 +2292,7 @@ msgid "searchInSection"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "searchLabel"
 msgstr "Rechercher sur le site"
 
@@ -2172,6 +2381,7 @@ msgid "section_undefined"
 msgstr "autre"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "sections"
 msgstr "Sections"
@@ -2208,6 +2418,7 @@ msgstr ""
 msgid "service_not_active"
 msgstr "Le service n'est pas actif"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "servizi"
 msgstr "Services"
@@ -2233,10 +2444,13 @@ msgstr "Disposer sur 4 colonnes"
 msgid "share"
 msgstr "Partager"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_description"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_detail_link"
 msgstr ""
@@ -2253,6 +2467,7 @@ msgstr ""
 msgid "show_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
 msgstr ""
@@ -2269,6 +2484,7 @@ msgstr ""
 msgid "show_map_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 msgid "show_only_first_ribbon"
 msgstr ""
@@ -2278,6 +2494,7 @@ msgid "show_pointer_list"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
 msgstr ""
@@ -2301,10 +2518,12 @@ msgstr ""
 msgid "silenzio_assenso"
 msgstr "Silence assentiment"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_compact"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_description"
 msgstr ""
@@ -2410,6 +2629,7 @@ msgid "termini_del_procedimento"
 msgstr "Termes de la procédure"
 
 #: components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/TextFilter
 msgid "text_filter_placeholder"
 msgstr "Entrez du texte"
 
@@ -2447,6 +2667,7 @@ msgid "to"
 msgstr "au"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti
 msgid "topics"
@@ -2497,6 +2718,7 @@ msgid "unita_organizzativa_competente"
 msgstr "Unité organisationnelle compétente pour la procédure"
 
 #: components/ItaliaTheme/View/Commons/RenderBlocks
+#: components/ItaliaTheme/View/Commons/TextOrBlocks
 msgid "unknownBlock"
 msgstr "Bloc inconnu"
 

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -23,6 +23,10 @@ msgstr "Accedi all'area personale"
 msgid "Add accordion item"
 msgstr "Aggiungi un elemento"
 
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "Add field"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
 msgid "Alert"
 msgstr "Alert"
@@ -31,6 +35,7 @@ msgstr "Alert"
 msgid "Allow Externals"
 msgstr "Accetta URL esterni per l'embed"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "Aspetto"
 msgstr "Aspetto"
@@ -55,6 +60,7 @@ msgstr "Stile del blocco"
 msgid "Card detail label"
 msgstr "Vedi"
 
+#: components/ItaliaTheme/Header/HeaderCenter
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 msgid "Cerca"
 msgstr "Cerca"
@@ -72,6 +78,7 @@ msgstr ""
 msgid "Cerca per parola chiave"
 msgstr "Cerca per parola chiave"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Clicca qui per sostituire il file"
 msgstr "Clicca qui per sostituire il file"
@@ -139,10 +146,23 @@ msgstr "Descrizione..."
 msgid "Dimensione della mappa"
 msgstr "Dimensione della mappa"
 
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email Success"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email sent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Error"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Etichetta location filter"
 msgstr "Etichetta"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Etichetta path filter"
@@ -155,6 +175,10 @@ msgstr "Non ho trovato la risposta che cercavi"
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Filtro location filter"
 msgstr "Filtro"
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "Form"
+msgstr ""
 
 #: components/ItaliaTheme/View/Commons/SkipToMainContent
 msgid "Go to content"
@@ -214,10 +238,12 @@ msgid "Link to"
 msgstr "Link a"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr "Link ad altro"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr "Titolo per il link ad altro"
 
@@ -235,6 +261,7 @@ msgstr "Menu selezionato"
 msgid "Mostra i filtri per luogo"
 msgstr "Mostra i filtri per luogo"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra i filtri per percorso"
@@ -242,6 +269,9 @@ msgstr "Mostra i filtri per percorso"
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra lo sfondo del blocco"
@@ -254,6 +284,14 @@ msgstr "Mostra tutti gli argomenti"
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
 msgstr "Nessun risultato ottenuto"
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
+msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
 msgid "Next page"
@@ -275,6 +313,7 @@ msgstr "Numero"
 msgid "Open in a new tab"
 msgstr "Apri in un nuovo tab"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Path filter filtro"
@@ -285,6 +324,7 @@ msgstr "Filtro"
 msgid "Pause slider"
 msgstr "Metti in pausa"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Percorso path filter"
@@ -304,6 +344,7 @@ msgstr "Pagina precedente"
 msgid "Required"
 msgstr "Required"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Rimuovi il file"
 msgstr "Rimuovi il file"
@@ -332,6 +373,7 @@ msgstr "Ricerca servizi"
 msgid "SearchServicesTitle"
 msgstr "Titolo"
 
+#: components/ItaliaTheme/Footer/FooterSocials
 #: components/ItaliaTheme/Header/SocialHeader
 msgid "Seguici su"
 msgstr "Seguici su"
@@ -344,6 +386,7 @@ msgstr ""
 msgid "Select all or none"
 msgstr "Seleziona tutti o nessuno"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Seleziona un file"
 msgstr "Seleziona un file"
@@ -380,6 +423,7 @@ msgstr "Iscriviti"
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Text placeholder"
 msgstr "Testo..."
@@ -397,24 +441,32 @@ msgid "Title"
 msgstr "Titolo"
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Body
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Title placeholder"
 msgstr "Titolo..."
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "Titolo"
 msgstr "Titolo"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui il file ..."
 msgstr "Trascina qui il file..."
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per caricare un nuovo file"
 msgstr "Trascina qui un file per caricare un nuovo file"
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per sostituire quello esistente"
 msgstr "Trascina qui un file per sostituire quello esistente"
@@ -423,12 +475,15 @@ msgstr "Trascina qui un file per sostituire quello esistente"
 msgid "Twitter Posts"
 msgstr "Twitter Posts"
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr "Digita la descrizione…"
 
+#: components/ItaliaTheme/Blocks/Accordion/TextEditorWidget
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -437,6 +492,7 @@ msgstr "Digita la descrizione…"
 msgid "Type text…"
 msgstr "Digita testo…"
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -466,6 +522,7 @@ msgstr "Vai alla pagina"
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
@@ -478,7 +535,10 @@ msgstr "Vedi"
 msgid "Vedi l'immagine"
 msgstr "Vedi l'immagine"
 
+#: components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate
 #: components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore
+#: components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate
+#: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 #: components/ItaliaTheme/MegaMenu/MegaMenu
@@ -518,14 +578,17 @@ msgid "advandedSectionsFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allFilters"
 msgstr "Tutto"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allOptions"
 msgstr "Tutte le opzioni"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allTopics"
 msgstr "Tutti gli argomenti"
 
@@ -545,10 +608,12 @@ msgstr "Altre modalità di invio"
 msgid "altri_documenti"
 msgstr "Altri documenti"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "always_show_image"
 msgstr "Mostra l'immagine per tutti gli elementi"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "amministrazione"
 msgstr "Amministrazione"
@@ -695,6 +760,7 @@ msgid "back"
 msgstr "indietro"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "backToSearch"
 msgstr "Torna alla ricerca"
 
@@ -764,6 +830,7 @@ msgstr "Colore di sfondo"
 msgid "biografia"
 msgstr "Biografia"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/BgColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "block_bg_color"
 msgstr "Colore di sfondo"
@@ -845,6 +912,7 @@ msgid "close"
 msgstr "chiudi"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "closeSearch"
 msgstr "Chiudi ricerca"
 
@@ -869,6 +937,10 @@ msgstr "Compensi"
 #: components/ItaliaTheme/View/UOView/UOView
 msgid "competenze"
 msgstr "Competenze"
+
+#: components/ItaliaTheme/Header/SearchModal
+msgid "confirmSearch"
+msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "contacts"
@@ -1143,6 +1215,8 @@ msgstr "Descrizione estesa"
 msgid "deselectSearchSection"
 msgstr "Non cercare nella sezione"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "detail_link_label"
 msgstr "Testo per il link al dettaglio"
@@ -1165,10 +1239,12 @@ msgstr "Dichiarazione dei redditi"
 msgid "dirigente"
 msgstr "Dirigente"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "documenti"
 msgstr "Documenti"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "documenti-e-dati"
 msgstr "Documenti e dati"
@@ -1247,6 +1323,7 @@ msgid "email_sede"
 msgstr "E-mail"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr "Seleziona un elemento nella barra laterale per mostrarlo qui."
 
@@ -1270,10 +1347,18 @@ msgstr "L'evento è di interesse per"
 msgid "event_documenti"
 msgstr "Documenti"
 
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_endDate"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/EventSearch/Edit
 #: components/ItaliaTheme/Blocks/UOSearch/Edit
 msgid "event_search_no_filters"
 msgstr "Nessun filtro da mostrare. Seleziona i filtri di ricerca da mostrare dalla sidebar laterale."
+
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_startDate"
+msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
 msgid "event_strutture_politiche"
@@ -1333,6 +1418,7 @@ msgid "file_correlato"
 msgstr "File correlato"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "filters"
 msgstr "Filtri"
 
@@ -1350,6 +1436,107 @@ msgstr "Cerca"
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 msgid "fine_termine"
 msgstr "Fine termine"
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_subject"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_default_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_empty_values_validation"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_input_values"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_required"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_attachment"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_checkbox"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_date"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_radio"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_select"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_text"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_textarea"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Field
+msgid "form_select_a_value"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_to"
+msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "foto_attivita_politica"
@@ -1401,6 +1588,9 @@ msgstr "Immagine precedente"
 msgid "grid-gallery-max-items-exceeded"
 msgstr "Per questo template il numero di risultati per pagina deve essere 7. Controlla le impostazioni."
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "hide_dates"
 msgstr "Nascondi le date"
@@ -1476,6 +1666,7 @@ msgstr "Link utili"
 msgid "listing_event_recurrence_label"
 msgstr "Questo evento ha più date: vedi tutte"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/ItemsColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "listing_items_color"
 msgstr "Colore dell'elemento"
@@ -1615,6 +1806,7 @@ msgstr "nominativo"
 msgid "notizie_in_evidenza"
 msgstr "Notizie in evidenza"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "novita"
 msgstr "Novità"
@@ -1628,42 +1820,51 @@ msgid "openLinkInNewTab"
 msgstr "Apri link in una nuova scheda"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionActiveContentButton"
 msgstr "Contenuto attivo"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentInfo"
 msgstr "Verranno esclusi dalla ricerca i contenuti archiviati e non più validi come gli eventi terminati o i bandi scaduti."
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentLabel"
 msgstr "Cerca solo tra i contenuti attivi"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateEnd"
 msgstr "Data fine"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateEndButton"
 msgstr "Al"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDatePlaceholder"
 msgstr "inserisci la data in formato gg/mm/aaaa"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateStart"
 msgstr "Data inizio"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateStartButton"
 msgstr "Dal"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "options"
 msgstr "Opzioni"
@@ -1738,6 +1939,10 @@ msgstr "Testo di aiuto"
 msgid "playStoreLink"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
 msgid "previewIconSelected"
 msgstr "Anteprima dell'icona scelta"
@@ -1796,11 +2001,13 @@ msgid "related_uo"
 msgstr "Amministrazione"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "removeOption"
 msgstr "Rimuovi opzione"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "removeTopic"
 msgstr "Rimuovi argomento"
 
@@ -1920,6 +2127,7 @@ msgid "scrivi_a_mail"
 msgstr "Scrivi all'indirizzo"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/SearchSectionForm
 msgid "search"
@@ -2067,6 +2275,7 @@ msgid "searchInSection"
 msgstr "Cerca nella sezione"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "searchLabel"
 msgstr "Cerca nel sito"
 
@@ -2155,6 +2364,7 @@ msgid "section_undefined"
 msgstr "altro"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "sections"
 msgstr "Sezioni"
@@ -2191,6 +2401,7 @@ msgstr ""
 msgid "service_not_active"
 msgstr "Il servizio non è attivo"
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "servizi"
 msgstr "Servizi"
@@ -2216,10 +2427,13 @@ msgstr "Disponi su 4 colonne"
 msgid "share"
 msgstr "Condividi"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_description"
 msgstr "Mostra la descrizione"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_detail_link"
 msgstr "Mostra il link al dettaglio"
@@ -2236,6 +2450,7 @@ msgstr ""
 msgid "show_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
 msgstr "Mostra l'icona"
@@ -2252,6 +2467,7 @@ msgstr ""
 msgid "show_map_full_width"
 msgstr "Mostra la mappa a tutta larghezza"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 msgid "show_only_first_ribbon"
 msgstr "Mostra il nastro solo sulla prima card"
@@ -2261,6 +2477,7 @@ msgid "show_pointer_list"
 msgstr "Mostra elenco puntato"
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
 msgstr "Mostra la sezione"
@@ -2284,10 +2501,12 @@ msgstr "Mostra il tipo"
 msgid "silenzio_assenso"
 msgstr "Silenzio assenso/Dichiarazione dell'interessato sostitutiva del provvedimento finale"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_compact"
 msgstr "Compatto"
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_description"
 msgstr "Qui puoi selezionare, per il template 'Card semplice', un aspetto diverso da quello di default."
@@ -2393,6 +2612,7 @@ msgid "termini_del_procedimento"
 msgstr "Termini del procedimento"
 
 #: components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/TextFilter
 msgid "text_filter_placeholder"
 msgstr "Inserisci un valore"
 
@@ -2430,6 +2650,7 @@ msgid "to"
 msgstr "al"
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti
 msgid "topics"
@@ -2480,6 +2701,7 @@ msgid "unita_organizzativa_competente"
 msgstr "Unità organizzativa competente del procedimento"
 
 #: components/ItaliaTheme/View/Commons/RenderBlocks
+#: components/ItaliaTheme/View/Commons/TextOrBlocks
 msgid "unknownBlock"
 msgstr "Blocco sconosciuto"
 

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -30,6 +30,10 @@ msgstr ""
 msgid "Add accordion item"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "Add field"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
 msgid "Alert"
 msgstr ""
@@ -38,6 +42,7 @@ msgstr ""
 msgid "Allow Externals"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "Aspetto"
 msgstr ""
@@ -62,6 +67,7 @@ msgstr ""
 msgid "Card detail label"
 msgstr ""
 
+#: components/ItaliaTheme/Header/HeaderCenter
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 msgid "Cerca"
 msgstr ""
@@ -79,6 +85,7 @@ msgstr ""
 msgid "Cerca per parola chiave"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Clicca qui per sostituire il file"
 msgstr ""
@@ -146,10 +153,23 @@ msgstr ""
 msgid "Dimensione della mappa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email Success"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email sent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Error"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Etichetta location filter"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Etichetta path filter"
@@ -161,6 +181,10 @@ msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Filtro location filter"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "Form"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/SkipToMainContent
@@ -221,10 +245,12 @@ msgid "Link to"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -242,6 +268,7 @@ msgstr ""
 msgid "Mostra i filtri per luogo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra i filtri per percorso"
@@ -249,6 +276,9 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra lo sfondo del blocco"
@@ -260,6 +290,14 @@ msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
 msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
@@ -282,6 +320,7 @@ msgstr ""
 msgid "Open in a new tab"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Path filter filtro"
@@ -292,6 +331,7 @@ msgstr ""
 msgid "Pause slider"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Percorso path filter"
@@ -311,6 +351,7 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Rimuovi il file"
 msgstr ""
@@ -339,6 +380,7 @@ msgstr ""
 msgid "SearchServicesTitle"
 msgstr ""
 
+#: components/ItaliaTheme/Footer/FooterSocials
 #: components/ItaliaTheme/Header/SocialHeader
 msgid "Seguici su"
 msgstr ""
@@ -351,6 +393,7 @@ msgstr ""
 msgid "Select all or none"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Seleziona un file"
 msgstr ""
@@ -387,6 +430,7 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Text placeholder"
 msgstr ""
@@ -404,24 +448,32 @@ msgid "Title"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Body
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Title placeholder"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "Titolo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui il file ..."
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per caricare un nuovo file"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per sostituire quello esistente"
 msgstr ""
@@ -430,12 +482,15 @@ msgstr ""
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Accordion/TextEditorWidget
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -444,6 +499,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -473,6 +529,7 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
@@ -485,7 +542,10 @@ msgstr ""
 msgid "Vedi l'immagine"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate
 #: components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore
+#: components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate
+#: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 #: components/ItaliaTheme/MegaMenu/MegaMenu
@@ -525,14 +585,17 @@ msgid "advandedSectionsFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allOptions"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allTopics"
 msgstr ""
 
@@ -552,10 +615,12 @@ msgstr ""
 msgid "altri_documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "always_show_image"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "amministrazione"
 msgstr ""
@@ -702,6 +767,7 @@ msgid "back"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "backToSearch"
 msgstr ""
 
@@ -771,6 +837,7 @@ msgstr ""
 msgid "biografia"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/BgColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "block_bg_color"
 msgstr ""
@@ -852,6 +919,7 @@ msgid "close"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "closeSearch"
 msgstr ""
 
@@ -875,6 +943,10 @@ msgstr ""
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 #: components/ItaliaTheme/View/UOView/UOView
 msgid "competenze"
+msgstr ""
+
+#: components/ItaliaTheme/Header/SearchModal
+msgid "confirmSearch"
 msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
@@ -1150,6 +1222,8 @@ msgstr ""
 msgid "deselectSearchSection"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "detail_link_label"
 msgstr ""
@@ -1172,10 +1246,12 @@ msgstr ""
 msgid "dirigente"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "documenti-e-dati"
 msgstr ""
@@ -1254,6 +1330,7 @@ msgid "email_sede"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1277,9 +1354,17 @@ msgstr ""
 msgid "event_documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_endDate"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/EventSearch/Edit
 #: components/ItaliaTheme/Blocks/UOSearch/Edit
 msgid "event_search_no_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_startDate"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
@@ -1340,6 +1425,7 @@ msgid "file_correlato"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "filters"
 msgstr ""
 
@@ -1356,6 +1442,107 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 msgid "fine_termine"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_subject"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_default_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_empty_values_validation"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_input_values"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_required"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_attachment"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_checkbox"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_date"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_radio"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_select"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_text"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_textarea"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Field
+msgid "form_select_a_value"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_to"
 msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
@@ -1408,6 +1595,9 @@ msgstr ""
 msgid "grid-gallery-max-items-exceeded"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "hide_dates"
 msgstr ""
@@ -1483,6 +1673,7 @@ msgstr ""
 msgid "listing_event_recurrence_label"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/ItemsColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "listing_items_color"
 msgstr ""
@@ -1622,6 +1813,7 @@ msgstr ""
 msgid "notizie_in_evidenza"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "novita"
 msgstr ""
@@ -1635,42 +1827,51 @@ msgid "openLinkInNewTab"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionActiveContentButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentInfo"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentLabel"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateEnd"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateEndButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDatePlaceholder"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateStart"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateStartButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "options"
 msgstr ""
@@ -1745,6 +1946,10 @@ msgstr ""
 msgid "playStoreLink"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
 msgid "previewIconSelected"
 msgstr ""
@@ -1803,11 +2008,13 @@ msgid "related_uo"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "removeOption"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "removeTopic"
 msgstr ""
 
@@ -1927,6 +2134,7 @@ msgid "scrivi_a_mail"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/SearchSectionForm
 msgid "search"
@@ -2074,6 +2282,7 @@ msgid "searchInSection"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "searchLabel"
 msgstr ""
 
@@ -2162,6 +2371,7 @@ msgid "section_undefined"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "sections"
 msgstr ""
@@ -2198,6 +2408,7 @@ msgstr ""
 msgid "service_not_active"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "servizi"
 msgstr ""
@@ -2223,10 +2434,13 @@ msgstr ""
 msgid "share"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_description"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_detail_link"
 msgstr ""
@@ -2243,6 +2457,7 @@ msgstr ""
 msgid "show_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
 msgstr ""
@@ -2259,6 +2474,7 @@ msgstr ""
 msgid "show_map_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 msgid "show_only_first_ribbon"
 msgstr ""
@@ -2268,6 +2484,7 @@ msgid "show_pointer_list"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
 msgstr ""
@@ -2291,10 +2508,12 @@ msgstr ""
 msgid "silenzio_assenso"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_compact"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_description"
 msgstr ""
@@ -2400,6 +2619,7 @@ msgid "termini_del_procedimento"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/TextFilter
 msgid "text_filter_placeholder"
 msgstr ""
 
@@ -2437,6 +2657,7 @@ msgid "to"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti
 msgid "topics"
@@ -2487,6 +2708,7 @@ msgid "unita_organizzativa_competente"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/RenderBlocks
+#: components/ItaliaTheme/View/Commons/TextOrBlocks
 msgid "unknownBlock"
 msgstr ""
 

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -42,6 +42,10 @@ msgstr ""
 msgid "Add accordion item"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "Add field"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
 msgid "Alert"
 msgstr ""
@@ -50,6 +54,7 @@ msgstr ""
 msgid "Allow Externals"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "Aspetto"
 msgstr ""
@@ -74,6 +79,7 @@ msgstr ""
 msgid "Card detail label"
 msgstr ""
 
+#: components/ItaliaTheme/Header/HeaderCenter
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 msgid "Cerca"
 msgstr ""
@@ -91,6 +97,7 @@ msgstr ""
 msgid "Cerca per parola chiave"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Clicca qui per sostituire il file"
 msgstr ""
@@ -158,10 +165,23 @@ msgstr ""
 msgid "Dimensione della mappa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email Success"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Email sent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "Error"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Etichetta location filter"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Etichetta path filter"
@@ -173,6 +193,10 @@ msgstr ""
 
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 msgid "Filtro location filter"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "Form"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/SkipToMainContent
@@ -233,10 +257,12 @@ msgid "Link to"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "LinkMore"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 msgid "Linkto title"
 msgstr ""
 
@@ -254,6 +280,7 @@ msgstr ""
 msgid "Mostra i filtri per luogo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra i filtri per percorso"
@@ -261,6 +288,9 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 msgid "Mostra lo sfondo del blocco"
@@ -272,6 +302,14 @@ msgstr ""
 
 #: components/ItaliaTheme/Search/Search
 msgid "Nessun risultato ottenuto"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+msgid "NewsHome"
 msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
@@ -294,6 +332,7 @@ msgstr ""
 msgid "Open in a new tab"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Path filter filtro"
@@ -304,6 +343,7 @@ msgstr ""
 msgid "Pause slider"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 msgid "Percorso path filter"
@@ -323,6 +363,7 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Rimuovi il file"
 msgstr ""
@@ -351,6 +392,7 @@ msgstr ""
 msgid "SearchServicesTitle"
 msgstr ""
 
+#: components/ItaliaTheme/Footer/FooterSocials
 #: components/ItaliaTheme/Header/SocialHeader
 msgid "Seguici su"
 msgstr ""
@@ -363,6 +405,7 @@ msgstr ""
 msgid "Select all or none"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Seleziona un file"
 msgstr ""
@@ -399,6 +442,7 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Text placeholder"
 msgstr ""
@@ -416,24 +460,32 @@ msgid "Title"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Body
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 msgid "Title placeholder"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "Titolo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui il file ..."
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per caricare un nuovo file"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 msgid "Trascina qui un file per sostituire quello esistente"
 msgstr ""
@@ -442,12 +494,15 @@ msgstr ""
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Accordion/TextEditorWidget
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
@@ -456,6 +511,7 @@ msgstr ""
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -485,6 +541,7 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
@@ -497,7 +554,10 @@ msgstr ""
 msgid "Vedi l'immagine"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate
 #: components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore
+#: components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate
+#: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 #: components/ItaliaTheme/MegaMenu/MegaMenu
@@ -537,14 +597,17 @@ msgid "advandedSectionsFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allOptions"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "allTopics"
 msgstr ""
 
@@ -564,10 +627,12 @@ msgstr ""
 msgid "altri_documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 msgid "always_show_image"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "amministrazione"
 msgstr ""
@@ -714,6 +779,7 @@ msgid "back"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "backToSearch"
 msgstr ""
 
@@ -783,6 +849,7 @@ msgstr ""
 msgid "biografia"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/BgColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "block_bg_color"
 msgstr ""
@@ -864,6 +931,7 @@ msgid "close"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "closeSearch"
 msgstr ""
 
@@ -887,6 +955,10 @@ msgstr ""
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 #: components/ItaliaTheme/View/UOView/UOView
 msgid "competenze"
+msgstr ""
+
+#: components/ItaliaTheme/Header/SearchModal
+msgid "confirmSearch"
 msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
@@ -1162,6 +1234,8 @@ msgstr ""
 msgid "deselectSearchSection"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "detail_link_label"
 msgstr ""
@@ -1184,10 +1258,12 @@ msgstr ""
 msgid "dirigente"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/PersonaView/PersonaView
 msgid "documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "documenti-e-dati"
 msgstr ""
@@ -1266,6 +1342,7 @@ msgid "email_sede"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 msgid "emptySelection"
 msgstr ""
 
@@ -1289,9 +1366,17 @@ msgstr ""
 msgid "event_documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_endDate"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/EventSearch/Edit
 #: components/ItaliaTheme/Blocks/UOSearch/Edit
 msgid "event_search_no_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+msgid "event_search_startDate"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
@@ -1352,6 +1437,7 @@ msgid "file_correlato"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "filters"
 msgstr ""
 
@@ -1368,6 +1454,107 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/TrasparenzaFields
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 msgid "fine_termine"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_from_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_default_subject"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_default_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+msgid "form_edit_warning_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+msgid "form_empty_values_validation"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_input_values"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_name_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_required"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_attachment"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_checkbox"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_date"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_radio"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_select"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_text"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_field_type_textarea"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Field
+msgid "form_select_a_value"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+msgid "form_to"
 msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
@@ -1420,6 +1607,9 @@ msgstr ""
 msgid "grid-gallery-max-items-exceeded"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "hide_dates"
 msgstr ""
@@ -1495,6 +1685,7 @@ msgstr ""
 msgid "listing_event_recurrence_label"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/ItemsColor
 #: config/Blocks/ListingOptions/defaultOptions
 msgid "listing_items_color"
 msgstr ""
@@ -1634,6 +1825,7 @@ msgstr ""
 msgid "notizie_in_evidenza"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "novita"
 msgstr ""
@@ -1647,42 +1839,51 @@ msgid "openLinkInNewTab"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionActiveContentButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentInfo"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionActiveContentLabel"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateEnd"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateEndButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDatePlaceholder"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "optionDateStart"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "optionDateStartButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "options"
 msgstr ""
@@ -1757,6 +1958,10 @@ msgstr ""
 msgid "playStoreLink"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+msgid "portata_di_click"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
 msgid "previewIconSelected"
 msgstr ""
@@ -1815,11 +2020,13 @@ msgid "related_uo"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "removeOption"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "removeTopic"
 msgstr ""
 
@@ -1939,6 +2146,7 @@ msgid "scrivi_a_mail"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/SearchSectionForm
 msgid "search"
@@ -2086,6 +2294,7 @@ msgid "searchInSection"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 msgid "searchLabel"
 msgstr ""
 
@@ -2174,6 +2383,7 @@ msgid "section_undefined"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 msgid "sections"
 msgstr ""
@@ -2210,6 +2420,7 @@ msgstr ""
 msgid "service_not_active"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 msgid "servizi"
 msgstr ""
@@ -2235,10 +2446,13 @@ msgstr ""
 msgid "share"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_description"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_detail_link"
 msgstr ""
@@ -2255,6 +2469,7 @@ msgstr ""
 msgid "show_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_icon"
 msgstr ""
@@ -2271,6 +2486,7 @@ msgstr ""
 msgid "show_map_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 msgid "show_only_first_ribbon"
 msgstr ""
@@ -2280,6 +2496,7 @@ msgid "show_pointer_list"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 msgid "show_section"
 msgstr ""
@@ -2303,10 +2520,12 @@ msgstr ""
 msgid "silenzio_assenso"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_compact"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 msgid "simplecard_listing_appearance_description"
 msgstr ""
@@ -2412,6 +2631,7 @@ msgid "termini_del_procedimento"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/TextFilter
 msgid "text_filter_placeholder"
 msgstr ""
 
@@ -2449,6 +2669,7 @@ msgid "to"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti
 msgid "topics"
@@ -2499,6 +2720,7 @@ msgid "unita_organizzativa_competente"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/RenderBlocks
+#: components/ItaliaTheme/View/Commons/TextOrBlocks
 msgid "unknownBlock"
 msgstr ""
 

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2022-01-10T15:57:31.272Z\n"
+"POT-Creation-Date: 2022-01-11T15:16:01.135Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -27,6 +27,11 @@ msgstr ""
 msgid "Add accordion item"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Edit
+# defaultMessage: Aggiungi un campo
+msgid "Add field"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/Alert/Sidebar
 # defaultMessage: Alert
 msgid "Alert"
@@ -37,6 +42,7 @@ msgstr ""
 msgid "Allow Externals"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 # defaultMessage: Aspetto
 msgid "Aspetto"
@@ -67,6 +73,7 @@ msgstr ""
 msgid "Card detail label"
 msgstr ""
 
+#: components/ItaliaTheme/Header/HeaderCenter
 #: components/ItaliaTheme/Header/HeaderSearch/HeaderSearch
 # defaultMessage: Cerca
 msgid "Cerca"
@@ -88,6 +95,7 @@ msgstr ""
 msgid "Cerca per parola chiave"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 # defaultMessage: Clicca qui per sostituire il file
 msgid "Clicca qui per sostituire il file"
@@ -170,11 +178,27 @@ msgstr ""
 msgid "Dimensione della mappa"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Form
+# defaultMessage: Email inviata correttamente
+msgid "Email Success"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+# defaultMessage: La tua mail è stata inviata correttamente
+msgid "Email sent"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+# defaultMessage: Errore
+msgid "Error"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 # defaultMessage: Etichetta
 msgid "Etichetta location filter"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Etichetta
@@ -189,6 +213,11 @@ msgstr ""
 #: components/ItaliaTheme/manage/Widgets/LocationFiltersWidget
 # defaultMessage: Filtro
 msgid "Filtro location filter"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Form
+msgid "Form"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/SkipToMainContent
@@ -263,11 +292,13 @@ msgid "Link to"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 # defaultMessage: Link ad altro
 msgid "LinkMore"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
 # defaultMessage: Testo per il link ad altro
 msgid "Linkto title"
 msgstr ""
@@ -289,6 +320,7 @@ msgstr ""
 msgid "Mostra i filtri per luogo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra i filtri per percorso
@@ -297,6 +329,9 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
 #: components/ItaliaTheme/Blocks/HeroImageLeft/HeroSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra lo sfondo del blocco
@@ -311,6 +346,16 @@ msgstr ""
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Nessun risultato ottenuto
 msgid "Nessun risultato ottenuto"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+# defaultMessage: News
+msgid "News"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/NewsHome/Sidebar
+# defaultMessage: News con immagine in primo piano
+msgid "NewsHome"
 msgstr ""
 
 #: components/ItaliaTheme/Pagination/PaginationItem
@@ -338,6 +383,7 @@ msgstr ""
 msgid "Open in a new tab"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Filtro
@@ -350,6 +396,7 @@ msgstr ""
 msgid "Pause slider"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: components/ItaliaTheme/manage/Widgets/PathFiltersWidget
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Percorso
@@ -373,6 +420,7 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 # defaultMessage: Rimuovi il file
 msgid "Rimuovi il file"
@@ -408,6 +456,7 @@ msgstr ""
 msgid "SearchServicesTitle"
 msgstr ""
 
+#: components/ItaliaTheme/Footer/FooterSocials
 #: components/ItaliaTheme/Header/SocialHeader
 # defaultMessage: Seguici su
 msgid "Seguici su"
@@ -423,6 +472,7 @@ msgstr ""
 msgid "Select all or none"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 # defaultMessage: Seleziona un file
 msgid "Seleziona un file"
@@ -467,6 +517,7 @@ msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 # defaultMessage: Text...
 msgid "Text placeholder"
@@ -487,28 +538,36 @@ msgid "Title"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
+#: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Body
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 # defaultMessage: Title...
 msgid "Title placeholder"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Calendar/ListingSidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/DefaultOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Titolo
 msgid "Titolo"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 # defaultMessage: Trascina qui il file...
 msgid "Trascina qui il file ..."
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 # defaultMessage: Trascina qui un file per caricare un nuovo file
 msgid "Trascina qui un file per caricare un nuovo file"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Form/Widgets/FileWidget
 #: components/ItaliaTheme/manage/Widgets/FileWidget
 # defaultMessage: Trascina qui un file per sostituire quello esistente
 msgid "Trascina qui un file per sostituire quello esistente"
@@ -519,6 +578,7 @@ msgstr ""
 msgid "Twitter Posts"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -526,15 +586,18 @@ msgstr ""
 msgid "Type description…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Accordion/TextEditorWidget
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/ArgumentsInEvidence/Block
 #: components/ItaliaTheme/Blocks/ContactsBlock/TextEditorWidget
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
 #: components/ItaliaTheme/manage/Widgets/TextEditorWidget
-# defaultMessage: Digita un testo…
+# defaultMessage: Type text…
 msgid "Type text…"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/Edit
 #: components/ItaliaTheme/Blocks/CTABlock/Block
 #: components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block
 #: components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block
@@ -569,6 +632,7 @@ msgstr ""
 #: components/ItaliaTheme/Blocks/Accordion/Block/EditBlock
 #: components/ItaliaTheme/Blocks/Accordion/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/ContactsBlock/Block/EditBlock
+#: components/ItaliaTheme/Blocks/Form/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/EditBlock
 #: components/ItaliaTheme/Blocks/IconBlocks/Block/ViewBlock
 #: components/ItaliaTheme/Blocks/Listing/MapTemplate
@@ -583,7 +647,10 @@ msgstr ""
 msgid "Vedi l'immagine"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/AmministrazioneTrasparenteTablesTemplate
 #: components/ItaliaTheme/Blocks/Listing/Commons/ListingLinkMore
+#: components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate
+#: components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithImageRssTemplate
 #: components/ItaliaTheme/Blocks/RssBlock/CardWithoutImageRssTemplate
 #: components/ItaliaTheme/MegaMenu/MegaMenu
@@ -632,16 +699,19 @@ msgid "advandedSectionsFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Tutto
 msgid "allFilters"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Tutte le date
 msgid "allOptions"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Tutti gli argomenti
 msgid "allTopics"
 msgstr ""
@@ -666,11 +736,13 @@ msgstr ""
 msgid "altri_documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Mostra l'immagine per tutti gli elementi
 msgid "always_show_image"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 # defaultMessage: Amministrazione
 msgid "amministrazione"
@@ -853,6 +925,7 @@ msgid "back"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Torna alla ricerca
 msgid "backToSearch"
 msgstr ""
@@ -938,6 +1011,7 @@ msgstr ""
 msgid "biografia"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/BgColor
 #: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Colore di sfondo
 msgid "block_bg_color"
@@ -1038,6 +1112,7 @@ msgid "close"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Chiudi cerca
 msgid "closeSearch"
 msgstr ""
@@ -1067,6 +1142,11 @@ msgstr ""
 #: components/ItaliaTheme/View/UOView/UOView
 # defaultMessage: Competenze
 msgid "competenze"
+msgstr ""
+
+#: components/ItaliaTheme/Header/SearchModal
+# defaultMessage: Conferma
+msgid "confirmSearch"
 msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
@@ -1407,6 +1487,8 @@ msgstr ""
 msgid "deselectSearchSection"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Testo per il link al dettaglio
 msgid "detail_link_label"
@@ -1434,11 +1516,13 @@ msgstr ""
 msgid "dirigente"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/PersonaView/PersonaView
-# defaultMessage: Documenti
+# defaultMessage: Documenti e dati
 msgid "documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 # defaultMessage: Documenti e dati
 msgid "documenti-e-dati"
@@ -1536,6 +1620,7 @@ msgid "email_sede"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Edit
+#: components/ItaliaTheme/Blocks/NewsHome/Edit
 # defaultMessage: Please select an item in the sidebar in order to show it here
 msgid "emptySelection"
 msgstr ""
@@ -1565,10 +1650,20 @@ msgstr ""
 msgid "event_documenti"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+# defaultMessage: Data fine
+msgid "event_search_endDate"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/EventSearch/Edit
 #: components/ItaliaTheme/Blocks/UOSearch/Edit
 # defaultMessage: Nessun filtro da mostrare. Seleziona i filtri di ricerca da mostrare dalla sidebar laterale.
 msgid "event_search_no_filters"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/DateFilter
+# defaultMessage: Data inizio
+msgid "event_search_startDate"
 msgstr ""
 
 #: components/ItaliaTheme/View/EventoView/EventoView
@@ -1643,6 +1738,7 @@ msgid "file_correlato"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Filtri
 msgid "filters"
 msgstr ""
@@ -1663,6 +1759,132 @@ msgstr ""
 #: components/ItaliaTheme/View/TrasparenzaView/DettagliProcedimentiView
 # defaultMessage: Fine termine
 msgid "fine_termine"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Mittente di default
+msgid "form_default_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Questo indirizzo verrà utilizzato come mittente della mail con i dati del form
+msgid "form_default_from_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Oggetto della mail
+msgid "form_default_subject"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+#: components/ItaliaTheme/Blocks/Form/Form
+# defaultMessage: Invia
+msgid "form_default_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+# defaultMessage: Attenzione!
+msgid "form_edit_warning"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Edit
+# defaultMessage: Inserire un campo di tipo "E-mail mittente". Se non è presente, oppure è presente ma non viene compilato dall'utente, l'indirizzo del mittente della mail sarà quello configurato dalla sidebar di destra.
+msgid "form_edit_warning_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Form
+# defaultMessage: Compila i campi richiesti
+msgid "form_empty_values_validation"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Descrizione
+msgid "form_field_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Valori possibili
+msgid "form_field_input_values"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Etichetta
+msgid "form_field_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Nome
+msgid "form_field_name"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Il nome deve contenere spazi, e può contenere solo caratteri alfanumerici oltre ai caratteri "-" e "_". Il nome coincide con il nome del parametro.
+msgid "form_field_name_description"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Obbligatorio
+msgid "form_field_required"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Tipo di campo
+msgid "form_field_type"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Allegato
+msgid "form_field_type_attachment"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Scelta multipla
+msgid "form_field_type_checkbox"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Data
+msgid "form_field_type_date"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: E-mail
+msgid "form_field_type_from"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Scelta singola
+msgid "form_field_type_radio"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Lista
+msgid "form_field_type_select"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Testo
+msgid "form_field_type_text"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Area di testo
+msgid "form_field_type_textarea"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Field
+# defaultMessage: Seleziona un valore
+msgid "form_select_a_value"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Testo sul bottone di invio
+msgid "form_submit_label"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/Form/Sidebar
+# defaultMessage: Destinatari
+msgid "form_to"
 msgstr ""
 
 #: components/ItaliaTheme/View/PersonaView/PersonaView
@@ -1727,6 +1949,9 @@ msgstr ""
 msgid "grid-gallery-max-items-exceeded"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/CardWithImageTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Nascondi le date
 msgid "hide_dates"
@@ -1818,6 +2043,7 @@ msgstr ""
 msgid "listing_event_recurrence_label"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/ItemsColor
 #: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Colore dell'elemento
 msgid "listing_items_color"
@@ -1989,6 +2215,7 @@ msgstr ""
 msgid "notizie_in_evidenza"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 # defaultMessage: Novità
 msgid "novita"
@@ -2005,50 +2232,59 @@ msgid "openLinkInNewTab"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Contenuto attivo
 msgid "optionActiveContentButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Verranno esclusi dalla ricerca i contenuti archiviati e non più validi come gli eventi terminati o i bandi scaduti.
 msgid "optionActiveContentInfo"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Cerca solo tra i contenuti attivi
 msgid "optionActiveContentLabel"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Data fine
 msgid "optionDateEnd"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Al
 msgid "optionDateEndButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: inserisci la data in formato gg/mm/aaaa
 msgid "optionDatePlaceholder"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Data inizio
 msgid "optionDateStart"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Dal
 msgid "optionDateStartButton"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Opzioni
 msgid "options"
@@ -2141,6 +2377,11 @@ msgstr ""
 msgid "playStoreLink"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/ArgomentoTitle/View
+# defaultMessage: A PORTATA DI CLICK
+msgid "portata_di_click"
+msgstr ""
+
 #: components/ItaliaTheme/manage/Widgets/IconPreviewWidget
 # defaultMessage: Anteprima dell'icona scelta
 msgid "previewIconSelected"
@@ -2211,12 +2452,14 @@ msgid "related_uo"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Rimuovi opzione
 msgid "removeOption"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Rimuovi argomento
 msgid "removeTopic"
 msgstr ""
@@ -2364,6 +2607,7 @@ msgid "scrivi_a_mail"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/SearchSectionForm
 # defaultMessage: Cerca
@@ -2539,6 +2783,7 @@ msgid "searchInSection"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 # defaultMessage: Cerca nel sito
 msgid "searchLabel"
 msgstr ""
@@ -2649,6 +2894,7 @@ msgid "section_undefined"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 # defaultMessage: Sezioni
 msgid "sections"
@@ -2694,6 +2940,7 @@ msgstr ""
 msgid "service_not_active"
 msgstr ""
 
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/View/Commons/RelatedItems
 # defaultMessage: Servizi
 msgid "servizi"
@@ -2725,11 +2972,14 @@ msgstr ""
 msgid "share"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra la descrizione
 msgid "show_description"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra il link al dettaglio
 msgid "show_detail_link"
@@ -2750,6 +3000,7 @@ msgstr ""
 msgid "show_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra l'icona
 msgid "show_icon"
@@ -2770,6 +3021,7 @@ msgstr ""
 msgid "show_map_full_width"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/RibbonCardTemplateOptions
 #: config/Blocks/ListingOptions/ribbonCardTemplate
 # defaultMessage: Mostra il nastro solo sulla prima card
 msgid "show_only_first_ribbon"
@@ -2781,6 +3033,7 @@ msgid "show_pointer_list"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/HighlightedContent/Sidebar
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: Mostra la sezione
 msgid "show_section"
@@ -2809,11 +3062,13 @@ msgstr ""
 msgid "silenzio_assenso"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 # defaultMessage: Compatto
 msgid "simplecard_listing_appearance_compact"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/Listing/Options/SimpleCardTemplateOptions
 #: config/Blocks/ListingOptions/simpleCardTemplate
 # defaultMessage: Qui puoi selezionare, per il template 'Card semplice', un aspetto diverso da quello di default.
 msgid "simplecard_listing_appearance_description"
@@ -2944,6 +3199,7 @@ msgid "termini_del_procedimento"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/Common/SearchFilters/TextFilter
+#: components/ItaliaTheme/Blocks/EventSearch/Filters/TextFilter
 # defaultMessage: Inserisci un valore
 msgid "text_filter_placeholder"
 msgstr ""
@@ -2989,6 +3245,7 @@ msgid "to"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
+#: components/ItaliaTheme/Header/SearchModal
 #: components/ItaliaTheme/Search/Search
 #: components/ItaliaTheme/View/Commons/PageHeader/PageHeaderTassonomiaArgomenti
 # defaultMessage: Argomenti
@@ -3049,6 +3306,7 @@ msgid "unita_organizzativa_competente"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/RenderBlocks
+#: components/ItaliaTheme/View/Commons/TextOrBlocks
 # defaultMessage: Blocco sconosciuto
 msgid "unknownBlock"
 msgstr ""

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -52,6 +52,8 @@ const CardWithImageTemplate = (props) => {
     natural_image_size = false,
   } = props;
 
+  const imagesToShow = set_four_columns ? 4 : 3;
+
   return (
     <div className="card-with-image-template">
       <Container className="px-4">
@@ -76,7 +78,8 @@ const CardWithImageTemplate = (props) => {
             ) : null;
             const image =
               item.image || item.immagine_testata || item.foto_persona;
-            const showImage = (index < 3 || always_show_image) && image;
+            const showImage =
+              (index < imagesToShow || always_show_image) && image;
             const category = getCategory(item, show_type, show_section, props);
             const topics = show_topics ? item.tassonomia_argomenti : null;
 


### PR DESCRIPTION
trovato guardando roba per Reggio con i listing cardWithImage a 4 colonne, era

![image](https://user-images.githubusercontent.com/41484878/148970130-75f236d9-ef3f-4f8e-b923-ffa2e67cbc27.png)


ora si vede cosi' dopo le modifiche

![image](https://user-images.githubusercontent.com/41484878/148970200-4d4c7f73-6ea0-4e8c-907f-3036f6c2f8bb.png)

