### PR TITLE
Fix small block link image

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SmallBlockLinksTemplate.jsx
@@ -25,7 +25,7 @@ const SmallBlockLinksTemplate = ({
         )}
         <Row className="items">
           {items.map((item, index) => {
-            const image = ListingImage({ item, maxSize: 200 });
+            const image = ListingImage({ item, maxSize: 200, style: {} });
 
             return (
               <Col

--- a/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_smallblockLinkstemplate.scss
@@ -9,6 +9,7 @@
     display: flex;
     height: 100px;
     align-items: center;
+    justify-content: center;
     padding: 56px 8px;
     border-right: none;
     background: white;
@@ -16,9 +17,10 @@
 
     img,
     .img-skeleton {
-      width: 100%;
-      height: auto;
-      max-height: 100px;
+      width: auto;
+      max-width: 100%;
+      height: 100px;
+      object-fit: contain;
     }
 
     .img-skeleton {


### PR DESCRIPTION
Questo sistema il problema con le immagini visto su Safari. Purtroppo Safari tratta i flexbox in maniera diversa dal resto del mondo.