### PR TITLE
fix: z-index of card with slide up text template

### DIFF
--- a/theme/ItaliaTheme/Blocks/_cardWithSlideUpTextTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_cardWithSlideUpTextTemplate.scss
@@ -18,6 +18,7 @@
 
   .box {
     position: relative;
+    z-index: 0;
     display: flex;
     height: 350px;
     flex-direction: column;


### PR DESCRIPTION
Risolto un problema di sovrapposizione del blocco con il dropdown del datepicker