### PR TITLE
chore: remove fixed dev proxy to api path

### DIFF
--- a/src/config/italiaConfig.js
+++ b/src/config/italiaConfig.js
@@ -75,7 +75,6 @@ export default function applyConfig(voltoConfig) {
 
   config.settings = {
     ...config.settings,
-    devProxyToApiPath: 'http://localhost:8080/Plone',
     sentryOptions: {
       ...(config.settings.sentryOptions ?? {}),
       ignoreErrors: [


### PR DESCRIPTION
Rimuoverei questa riga. Ad oggi non è possibile settare al volo questo parametro con una variabile d'ambiente, perché questa vince di base, quindi l'unico modo sarebbe fare l'override in ogni proprio progetto personale, ove necessario.