### PR TITLE
fix: reading fullobjects from variation config

### DIFF
--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -239,6 +239,7 @@ const italiaListingVariations = [
   //    id: 'amministrazioneTrasparenteTablesTemplate',
   //    isDefault: false,
   //    title: 'Tabelle Amministrazione Trasparente',
+  //    fullobjects: 1,
   //    template: AmministrazioneTrasparenteTablesTemplate,
   //    skeleton: AmministrazioneTrasparenteTablesTemplateSkeleton,
   //    schemaEnhancer: ({ schema, formData, intl }) => {

--- a/src/customizations/volto/components/manage/Blocks/Listing/withQuerystringResults.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Listing/withQuerystringResults.jsx
@@ -17,6 +17,12 @@ function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }
 
+const getVariationSettings = (variation) => {
+  return config?.blocks?.blocksConfig?.listing?.variations?.find(
+    (v) => v.id === variation,
+  );
+};
+
 const getAdaptedQuery = (querystring, b_size, variation) => {
   const copyFields = [
     'limit',
@@ -27,8 +33,12 @@ const getAdaptedQuery = (querystring, b_size, variation) => {
     ...(config.settings.querystringAdditionalFields ?? []),
   ];
 
+  const variationSettings = getVariationSettings(variation) ?? {};
+
   return Object.assign(
-    variation?.fullobjects ? { fullobjects: 1 } : { metadata_fields: '_all' },
+    variationSettings?.fullobjects
+      ? { fullobjects: 1 }
+      : { metadata_fields: '_all' },
     {
       b_size: b_size,
     },


### PR DESCRIPTION
Actually we are not able to read "fullobjects" option from variation configuration