### PR TITLE
chore: added readraft helper function and fixed text of contacts form

### DIFF
--- a/src/components/ItaliaTheme/Blocks/ContactsBlock/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/ContactsBlock/Block/ViewBlock.jsx
@@ -10,6 +10,7 @@ import redraft from 'redraft';
 import { Icon } from '@italia/components/ItaliaTheme';
 import { Card, CardBody } from 'design-react-kit/dist/design-react-kit';
 import config from '@plone/volto/registry';
+import { checkRedraftHasContent } from '@italia/helpers';
 
 /**
  * ViewBlock class.
@@ -25,7 +26,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
       tag="div"
     >
       <CardBody tag="div">
-        {data.title && (
+        {checkRedraftHasContent(data.title) && (
           <div className="contact-title">
             {redraft(
               data.title,
@@ -34,7 +35,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
             )}
           </div>
         )}
-        {data.text && (
+        {checkRedraftHasContent(data.text) && (
           <div className="contact-text">
             {redraft(
               data.text,
@@ -44,7 +45,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
           </div>
         )}
 
-        {data.tel && (
+        {checkRedraftHasContent(data.tel) && (
           <div className="contact-info">
             <div className="icon-wrapper">
               <Icon icon="phone-alt" />
@@ -59,7 +60,7 @@ const ViewBlock = ({ data, isOpen, toggle, id, index }) => {
           </div>
         )}
 
-        {data.email && (
+        {checkRedraftHasContent(data.email) && (
           <div className="contact-info">
             <div className="icon-wrapper">
               <Icon icon="envelope" />

--- a/src/components/ItaliaTheme/Blocks/CountDown/View.jsx
+++ b/src/components/ItaliaTheme/Blocks/CountDown/View.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import redraft from 'redraft';
+import { checkRedraftHasContent } from '@italia/helpers';
 import { Container, Row, Col } from 'design-react-kit/dist/design-react-kit';
 import { addAppURL, flattenToAppURL } from '@plone/volto/helpers';
 import cx from 'classnames';
@@ -8,13 +9,6 @@ import CountDown from '@italia/components/ItaliaTheme/Blocks/CountDown/CountDown
 import config from '@plone/volto/registry';
 
 const View = ({ data, id }) => {
-  const checkHasContent = (text) => {
-    if (text) {
-      let blocks = text.blocks.filter((block) => block?.text !== '');
-      return blocks.length > 0 ? true : false;
-    }
-  };
-
   return (
     <div className="block count_down">
       <div className="public-ui">
@@ -39,7 +33,7 @@ const View = ({ data, id }) => {
           )}
           <Container className="px-md-4">
             <Row>
-              {checkHasContent(data.text) && (
+              {checkRedraftHasContent(data.text) && (
                 <Col
                   xs={{
                     size: 12,
@@ -73,7 +67,7 @@ const View = ({ data, id }) => {
                   showMinutes={data.showMinutes}
                   showSeconds={data.showSeconds}
                 />
-                {checkHasContent(data.countdown_text) && (
+                {checkRedraftHasContent(data.countdown_text) && (
                   <div className="countdown_text">
                     {redraft(
                       data.countdown_text,

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -11,6 +11,7 @@ export {
   getEventRecurrenceMore,
 } from '@italia/helpers/ListingHelper';
 export { contentFolderHasItems } from '@italia/helpers/contentHelper';
+export { checkRedraftHasContent } from '@italia/helpers/redraftHelper';
 export { getTableRowData } from '@italia/helpers/amministrazioneTrasparenteHelper';
 export { getItemsByPath } from '@italia/helpers/getItemsByPath';
 export { viewDate } from '@italia/helpers/dates';

--- a/src/helpers/redraftHelper.js
+++ b/src/helpers/redraftHelper.js
@@ -1,0 +1,9 @@
+/*
+  Used to verify that redraft text blocks are empty
+*/
+export const checkRedraftHasContent = (text) => {
+  if (text) {
+    let blocks = text.blocks.filter((block) => block?.text !== '');
+    return blocks.length > 0 ? true : false;
+  }
+};

--- a/theme/ItaliaTheme/Blocks/_contacts.scss
+++ b/theme/ItaliaTheme/Blocks/_contacts.scss
@@ -122,13 +122,21 @@
 
     .contact-info {
       display: flex;
-      align-items: center;
+
+      &:first-of-type {
+        align-items: center;
+
+        .icon-wrapper {
+          margin-top: 0;
+        }
+      }
 
       &:not(:last-of-type) {
         margin-bottom: 1rem;
       }
 
       .icon-wrapper {
+        margin-top: 0.2rem;
         margin-right: 1rem;
       }
 
@@ -143,6 +151,7 @@
       .tel,
       .email {
         flex: 1 1 auto;
+        word-break: break-word;
 
         .DraftEditor-editorContainer {
           line-height: 1.48em;


### PR DESCRIPTION
- Aggiunta una funzione tra gli helpers per quegli elementi textEditor che una volta compilati e cancellato il contenuto il blocco continua ad essere mostrato vuoto
- Applicate modifiche al testo del blocco contatti che fuoriusciva dalle card se troppo lungo