### PR TITLE
chore: improve srcset image quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@plone/volto": "plone/volto#774a78ac50d7ed1b2903d6f1e5b63b5c0d33d413",
+    "@plone/volto": "plone/volto#e4b1a8cc407b5781fed154327bfe8fef4655c886",
     "@tinymce/tinymce-react": "3.8.1",
     "bootstrap-italia": "1.3.9",
     "classnames": "2.2.6",

--- a/src/components/ItaliaTheme/Blocks/Listing/GridGalleryTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/GridGalleryTemplate.jsx
@@ -10,7 +10,6 @@ import {
   Col,
   Alert,
 } from 'design-react-kit/dist/design-react-kit';
-import { flattenToAppURL } from '@plone/volto/helpers';
 
 const messages = defineMessages({
   maxItemsExceeded: {
@@ -50,26 +49,9 @@ const GridGalleryTemplate = ({
           {items.map((item, index) => {
             let image = ListingImage({
               item,
-              useOriginal: true,
+              useOriginal: false,
               className: '',
             });
-
-            if (item[item.image_field]?.scales?.large) {
-              let src = item[item.image_field].scales.large.download;
-
-              image = (
-                <picture className="volto-image">
-                  <img
-                    src={flattenToAppURL(src)}
-                    alt=""
-                    role="presentation"
-                    loading="lazy"
-                    aria-hidden="true"
-                    style={{ width: '100%', 'object-fit': 'cover' }}
-                  />
-                </picture>
-              );
-            }
 
             return (
               <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,9 +1974,9 @@
     pofile "1.0.10"
     razzle "3.4.5"
 
-"@plone/volto@plone/volto#774a78ac50d7ed1b2903d6f1e5b63b5c0d33d413":
+"@plone/volto@plone/volto#e4b1a8cc407b5781fed154327bfe8fef4655c886":
   version "15.0.0-alpha.3"
-  resolved "https://codeload.github.com/plone/volto/tar.gz/774a78ac50d7ed1b2903d6f1e5b63b5c0d33d413"
+  resolved "https://codeload.github.com/plone/volto/tar.gz/e4b1a8cc407b5781fed154327bfe8fef4655c886"
   dependencies:
     "@babel/plugin-proposal-export-default-from" "7.10.4"
     "@babel/plugin-proposal-export-namespace-from" "7.10.4"


### PR DESCRIPTION
Qui non si vede più di tanto, la vera modifica è su volto, che ora tiene conto anche del device pixel ratio: https://github.com/plone/volto/blob/7b6af2e44585f9cfe7127dc61e7430777ba89f48/src/components/theme/Image/Image.jsx#L61 
motivo per cui su mobile si vedevano molto sgranate.
Le immagini full-width purtroppo su monitor grandi avranno sempre un po' di sgranatura, perchè la miniatura massima è di 1600px 