### PR TITLE
fix: fix paste links and image urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@plone/volto": "plone/volto#ab25974db4e0d9b659dd01aabdf26a2ff6c65b2e",
+    "@plone/volto": "plone/volto#f435e097263b184873f4eb96cfb70af050fe4a26",
     "@tinymce/tinymce-react": "3.8.1",
     "bootstrap-italia": "1.3.9",
     "classnames": "2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,9 +1974,9 @@
     pofile "1.0.10"
     razzle "3.4.5"
 
-"@plone/volto@plone/volto#ab25974db4e0d9b659dd01aabdf26a2ff6c65b2e":
+"@plone/volto@plone/volto#f435e097263b184873f4eb96cfb70af050fe4a26":
   version "15.4.1"
-  resolved "https://codeload.github.com/plone/volto/tar.gz/ab25974db4e0d9b659dd01aabdf26a2ff6c65b2e"
+  resolved "https://codeload.github.com/plone/volto/tar.gz/f435e097263b184873f4eb96cfb70af050fe4a26"
   dependencies:
     "@babel/plugin-proposal-export-default-from" "7.10.4"
     "@babel/plugin-proposal-export-namespace-from" "7.10.4"


### PR DESCRIPTION
Aggiornata la versione di Volto per fissare un bug che si verificava nel momento in cui si incollava un url interno in un campo link o in un blocco immagine