### PR TITLE
feat: light loading of videos

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -1923,6 +1923,12 @@ msgstr ""
 msgid "listing_items_color"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
+#: components/ItaliaTheme/View/Commons/EmbeddedVideo
+# defaultMessage: Premi Invio per caricare il video, poi premi Tab per navigare sul video.
+msgid "loadVideo"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -1908,6 +1908,12 @@ msgstr "This event has multiple dates: see all"
 msgid "listing_items_color"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
+#: components/ItaliaTheme/View/Commons/EmbeddedVideo
+# defaultMessage: Premi Invio per caricare il video, poi premi Tab per navigare sul video.
+msgid "loadVideo"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -1925,6 +1925,12 @@ msgstr "Cet événement a plusieurs dates: tout voir"
 msgid "listing_items_color"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
+#: components/ItaliaTheme/View/Commons/EmbeddedVideo
+# defaultMessage: Premi Invio per caricare il video, poi premi Tab per navigare sul video.
+msgid "loadVideo"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -1908,6 +1908,12 @@ msgstr "Questo evento ha più date: vedi tutte"
 msgid "listing_items_color"
 msgstr "Colore dell'elemento"
 
+#: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
+#: components/ItaliaTheme/View/Commons/EmbeddedVideo
+# defaultMessage: Premi Invio per caricare il video, poi premi Tab per navigare sul video.
+msgid "loadVideo"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -1915,6 +1915,12 @@ msgstr ""
 msgid "listing_items_color"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
+#: components/ItaliaTheme/View/Commons/EmbeddedVideo
+# defaultMessage: Premi Invio per caricare il video, poi premi Tab per navigare sul video.
+msgid "loadVideo"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -1927,6 +1927,12 @@ msgstr ""
 msgid "listing_items_color"
 msgstr ""
 
+#: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
+#: components/ItaliaTheme/View/Commons/EmbeddedVideo
+# defaultMessage: Premi Invio per caricare il video, poi premi Tab per navigare sul video.
+msgid "loadVideo"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar
 #: components/ItaliaTheme/Blocks/EventSearch/Sidebar
 #: components/ItaliaTheme/Blocks/UOSearch/Sidebar

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2022-04-15T12:13:54.270Z\n"
+"POT-Creation-Date: 2022-04-21T15:21:55.145Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -1908,6 +1908,12 @@ msgstr ""
 #: config/Blocks/ListingOptions/defaultOptions
 # defaultMessage: Colore dell'elemento
 msgid "listing_items_color"
+msgstr ""
+
+#: components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock
+#: components/ItaliaTheme/View/Commons/EmbeddedVideo
+# defaultMessage: Premi Invio per caricare il video, poi premi Tab per navigare sul video.
+msgid "loadVideo"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/BandiSearch/Sidebar

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@fortawesome/free-regular-svg-icons": "5.14.0",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@fortawesome/react-fontawesome": "0.1.11",
-    "@plone/volto": "plone/volto#f435e097263b184873f4eb96cfb70af050fe4a26",
+    "@plone/volto": "plone/volto#fedfca2c894b0a288af2eff95ef9fc8d19a85eec",
     "@tinymce/tinymce-react": "3.8.1",
     "bootstrap-italia": "1.3.9",
     "classnames": "2.2.6",

--- a/src/components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock.jsx
@@ -53,7 +53,7 @@ const ViewBlock = ({ data, index, isEditMode = false }) => {
 
   const ref = React.createRef();
   const onKeyDown = (e) => {
-    if (e.nativeEvent.keyCode === 13) {
+    if (e.nativeEvent.keyCode === 13) { //Enter
       ref.current.handleClick();
     }
   };

--- a/src/components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock.jsx
@@ -40,9 +40,10 @@ const ViewBlock = ({ data, index, isEditMode = false }) => {
     if (data.url.match('youtu')) {
       if (!placeholder) {
         //load video preview image from youtube
-        const videoID = data.url
-          .match(/youtube\.com.*(\?v=|\/embed\/)(.{11})/)
-          .pop();
+
+        const videoID = data.url.match(/.be\//)
+          ? data.url.match(/^.*\.be\/(.*)/)?.[1]
+          : data.url.match(/^.*\?v=(.*)$/)?.[1];
         placeholder =
           'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';
       }

--- a/src/components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock.jsx
@@ -38,7 +38,6 @@ const ViewBlock = ({ data, index, isEditMode = false }) => {
 
   if (!placeholder && data.url) {
     if (data.url.match('youtu')) {
-      if (!placeholder) {
         //load video preview image from youtube
 
         const videoID = data.url.match(/.be\//)
@@ -46,7 +45,6 @@ const ViewBlock = ({ data, index, isEditMode = false }) => {
           : data.url.match(/^.*\?v=(.*)$/)?.[1];
         placeholder =
           'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';
-      }
     } else if (data.url.match('vimeo')) {
       const videoID = data.url.match(/^.*\.com\/(.*)/)[1];
       placeholder = 'https://vumbnail.com/' + videoID + '.jpg';

--- a/src/components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock.jsx
+++ b/src/components/ItaliaTheme/Blocks/VideoGallery/Block/ViewBlock.jsx
@@ -6,22 +6,80 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Embed } from 'semantic-ui-react';
-import { isInternalURL, getParentUrl } from '@plone/volto/helpers';
+import {
+  isInternalURL,
+  getParentUrl,
+  flattenToAppURL,
+} from '@plone/volto/helpers';
 import { ConditionalEmbed } from 'volto-gdpr-privacy';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useIntl, defineMessages } from 'react-intl';
 import config from '@plone/volto/registry';
 
+const messages = defineMessages({
+  loadVideo: {
+    id: 'loadVideo',
+    defaultMessage:
+      'Premi Invio per caricare il video, poi premi Tab per navigare sul video.',
+  },
+});
 /**
  * ViewBlock class.
  * @class ViewBlock
  * @extends Component
  */
 const ViewBlock = ({ data, index, isEditMode = false }) => {
+  const intl = useIntl();
+  let placeholder = data.preview_image
+    ? isInternalURL(data.preview_image)
+      ? `${flattenToAppURL(data.preview_image)}/@@images/image`
+      : data.preview_image
+    : null;
+
+  if (!placeholder && data.url) {
+    if (data.url.match('youtu')) {
+      if (!placeholder) {
+        //load video preview image from youtube
+        const videoID = data.url
+          .match(/youtube\.com.*(\?v=|\/embed\/)(.{11})/)
+          .pop();
+        placeholder =
+          'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';
+      }
+    } else if (data.url.match('vimeo')) {
+      const videoID = data.url.match(/^.*\.com\/(.*)/)[1];
+      placeholder = 'https://vumbnail.com/' + videoID + '.jpg';
+    }
+  }
+
+  const ref = React.createRef();
+  const onKeyDown = (e) => {
+    if (e.nativeEvent.keyCode === 13) {
+      ref.current.handleClick();
+    }
+  };
+
   const embedSettings = {
-    icon: 'play',
-    defaultActive: true,
+    icon: (
+      <div
+        className="icon-play"
+        role="button"
+        tabIndex={0}
+        title="Download and Play video"
+      >
+        <FontAwesomeIcon icon={['fas', 'play']} />
+      </div>
+    ),
+    defaultActive: false,
     autoplay: false,
     aspectRatio: '16:9',
+    placeholder: placeholder,
+    tabIndex: 0,
+    onKeyPress: onKeyDown,
+    ref: ref,
+    'aria-label': intl.formatMessage(messages.loadVideo),
   };
+
   return data?.url ? (
     <div className="video-wrapper">
       <ConditionalEmbed url={!isEditMode ? data.url : null}>

--- a/src/components/ItaliaTheme/View/Commons/EmbeddedVideo.jsx
+++ b/src/components/ItaliaTheme/View/Commons/EmbeddedVideo.jsx
@@ -28,7 +28,7 @@ const EmbeddedVideo = ({ video_url, title, id }) => {
 
   const ref = React.createRef();
   const onKeyDown = (e) => {
-    if (e.nativeEvent.keyCode === 13) {
+    if (e.nativeEvent.keyCode === 13) { //Enter
       ref.current.handleClick();
     }
   };

--- a/src/components/ItaliaTheme/View/Commons/EmbeddedVideo.jsx
+++ b/src/components/ItaliaTheme/View/Commons/EmbeddedVideo.jsx
@@ -1,8 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ConditionalEmbed } from 'volto-gdpr-privacy';
+import { Embed } from 'semantic-ui-react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useIntl, defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  loadVideo: {
+    id: 'loadVideo',
+    defaultMessage:
+      'Premi Invio per caricare il video, poi premi Tab per navigare sul video.',
+  },
+});
 
 const EmbeddedVideo = ({ video_url, title, id }) => {
+  const intl = useIntl();
   /* Needed to fix error:
     "Refused to display 'https://www.youtube.com/watch?v=ID&feature=youtu.be'
     in a frame because it set 'X-Frame-Options' to 'sameorigin'."
@@ -10,22 +22,47 @@ const EmbeddedVideo = ({ video_url, title, id }) => {
     It seems youtube /watch endpoint refuses this format for embedded videos.
     Need to reformat url to /embed endpoint
   */
-  const video_id = video_url.split('/').splice(-1);
-  const src = `https://youtube.com/embed/${video_id}`;
+  const video_id = video_url.match(/.be\//)
+    ? video_url.match(/^.*\.be\/(.*)/)?.[1]
+    : video_url.match(/^.*\?v=(.*)$/)?.[1];
+
+  const ref = React.createRef();
+  const onKeyDown = (e) => {
+    if (e.nativeEvent.keyCode === 13) {
+      ref.current.handleClick();
+    }
+  };
+
+  const embedSettings = {
+    icon: (
+      <div
+        className="icon-play"
+        role="button"
+        tabIndex={0}
+        title="Download and Play video"
+      >
+        <FontAwesomeIcon icon={['fas', 'play']} />
+      </div>
+    ),
+    defaultActive: false,
+    autoplay: false,
+    aspectRatio: '16:9',
+    placeholder: 'https://img.youtube.com/vi/' + video_id + '/sddefault.jpg',
+    tabIndex: 0,
+    onKeyPress: onKeyDown,
+    ref: ref,
+    'aria-label': intl.formatMessage(messages.loadVideo),
+  };
+
   return video_url ? (
-    <div
-      key={id}
-      className="embed-responsive embed-responsive-16by9 my4"
-      id={`embedded-video-${id}`}
-    >
-      <ConditionalEmbed url={src} key={'embedvideo' + id}>
-        <iframe
-          loading="lazy"
-          className="embed-responsive-item"
+    <div key={id} className="embedded-video my4" id={`embedded-video-${id}`}>
+      <ConditionalEmbed url={video_url} key={'embedvideo' + id}>
+        <Embed
+          id={video_id}
           title={title || `YouTube Video ${id}`}
-          allowFullScreen
-          src={src}
-        ></iframe>
+          source="youtube"
+          {...embedSettings}
+        />
       </ConditionalEmbed>
     </div>
   ) : null;

--- a/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
@@ -1,0 +1,178 @@
+/**
+ * Body video block.
+ * @module components/manage/Blocks/Video/Body
+ *
+ * Customizations:
+ * - support external sources for preview image
+ * - added ConditionalEmbed
+ * - changed icon for preview with FontAwesome icon
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Embed, Message } from 'semantic-ui-react';
+import cx from 'classnames';
+import {
+  isInternalURL,
+  getParentUrl,
+  flattenToAppURL,
+} from '@plone/volto/helpers';
+import { ConditionalEmbed } from 'volto-gdpr-privacy';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import config from '@plone/volto/registry';
+
+/**
+ * Body video block class.
+ * @class Body
+ * @extends Component
+ */
+const Body = ({ data, isEditMode }) => {
+  const allowsExternals =
+    data.allowExternals !== undefined
+      ? !!data.allowExternals
+      : !!config.settings.videoAllowExternalsDefault;
+
+  let placeholder = data.preview_image
+    ? isInternalURL(data.preview_image)
+      ? `${flattenToAppURL(data.preview_image)}/@@images/image`
+      : data.preview_image
+    : null;
+
+  let videoID = null;
+  let listID = null;
+
+  if (!placeholder && data.url) {
+    if (data.url.match('youtu')) {
+      if (!placeholder) {
+        //load video preview image from youtube
+        if (data.url.match('list')) {
+          listID = data.url.match(/^.*\?list=|^.*&list=(.*)$/)[1];
+          videoID = data.url.match(/^.*\?v=(.*)&(.*)$/)[1];
+        } else {
+          videoID = data.url.match(/.be\//)
+            ? data.url.match(/^.*\.be\/(.*)/)[1]
+            : data.url.match(/^.*\?v=(.*)$/)[1];
+        }
+
+        placeholder =
+          'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';
+      }
+    } else if (data.url.match('vimeo')) {
+      videoID = data.url.match(/^.*\.com\/(.*)/)[1];
+      placeholder = 'https://vumbnail.com/' + videoID + '.jpg';
+    }
+  }
+
+  const ref = React.createRef();
+  const onKeyDown = (e) => {
+    if (e.nativeEvent.keyCode === 13) {
+      ref.current.handleClick();
+    }
+  };
+  const embedSettings = {
+    placeholder: placeholder,
+    icon: (
+      <div
+        className="icon-play"
+        role="button"
+        tabIndex={0}
+        title="Load and Play video"
+      >
+        <FontAwesomeIcon icon={['fas', 'play']} />
+      </div>
+    ),
+    defaultActive: false,
+    autoplay: false,
+    aspectRatio: '16:9',
+    tabIndex: 0,
+    onKeyPress: onKeyDown,
+    ref: ref,
+  };
+
+  return (
+    <>
+      {data.url && (
+        <div
+          className={cx('video-inner', {
+            'full-width': data.align === 'full',
+          })}
+        >
+          <ConditionalEmbed url={data.url}>
+            {data.url.match('youtu') ? (
+              <>
+                {data.url.match('list') ? (
+                  <Embed
+                    url={`https://www.youtube.com/embed/videoseries?list=${listID}`}
+                    {...embedSettings}
+                  />
+                ) : (
+                  <Embed id={videoID} source="youtube" {...embedSettings} />
+                )}
+              </>
+            ) : (
+              <>
+                {data.url.match('vimeo') ? (
+                  <Embed id={videoID} source="vimeo" {...embedSettings} />
+                ) : (
+                  <>
+                    {data.url.match('.mp4') ? (
+                      // eslint-disable-next-line jsx-a11y/media-has-caption
+                      <video
+                        src={
+                          isInternalURL(
+                            data.url.replace(
+                              getParentUrl(config.settings.apiPath),
+                              '',
+                            ),
+                          )
+                            ? `${data.url}/@@download/file`
+                            : data.url
+                        }
+                        controls
+                        poster={placeholder}
+                        type="video/mp4"
+                      />
+                    ) : data.url && allowsExternals ? (
+                      // eslint-disable-next-line jsx-a11y/media-has-caption
+                      <video
+                        src={data.url}
+                        controls
+                        poster={placeholder}
+                        type="video/mp4"
+                      />
+                    ) : isEditMode ? (
+                      <div>
+                        <Message>
+                          <center>
+                            <FormattedMessage
+                              id="Please enter a valid URL by deleting the block and adding a new video block."
+                              defaultMessage="Please enter a valid URL by deleting the block and adding a new video block."
+                            />
+                          </center>
+                        </Message>
+                      </div>
+                    ) : (
+                      <div className="invalidVideoFormat" />
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </ConditionalEmbed>
+        </div>
+      )}
+    </>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+Body.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any).isRequired,
+};
+
+export default Body;

--- a/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
@@ -64,7 +64,7 @@ const Body = ({ data, isEditMode }) => {
 
   const ref = React.createRef();
   const onKeyDown = (e) => {
-    if (e.nativeEvent.keyCode === 13) {
+    if (e.nativeEvent.keyCode === 13) { //Enter
       ref.current.handleClick();
     }
   };

--- a/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Body.jsx
@@ -43,8 +43,7 @@ const Body = ({ data, isEditMode }) => {
   let listID = null;
 
   if (!placeholder && data.url) {
-    if (data.url.match('youtu')) {
-      if (!placeholder) {
+    if (data.url.match('youtu')) {      
         //load video preview image from youtube
         if (data.url.match('list')) {
           listID = data.url.match(/^.*\?list=|^.*&list=(.*)$/)[1];
@@ -56,8 +55,7 @@ const Body = ({ data, isEditMode }) => {
         }
 
         placeholder =
-          'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';
-      }
+          'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';      
     } else if (data.url.match('vimeo')) {
       videoID = data.url.match(/^.*\.com\/(.*)/)[1];
       placeholder = 'https://vumbnail.com/' + videoID + '.jpg';

--- a/src/customizations/volto/components/manage/Blocks/Video/Edit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/Edit.jsx
@@ -5,8 +5,8 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { Button, Input, Embed, Message } from 'semantic-ui-react';
+import { defineMessages, injectIntl } from 'react-intl';
+import { Button, Input, Message } from 'semantic-ui-react';
 import cx from 'classnames';
 import { isEqual } from 'lodash';
 
@@ -14,12 +14,7 @@ import { Icon, SidebarPortal, VideoSidebar } from '@plone/volto/components';
 import clearSVG from '@plone/volto/icons/clear.svg';
 import aheadSVG from '@plone/volto/icons/ahead.svg';
 import videoBlockSVG from '@plone/volto/components/manage/Blocks/Video/block-video.svg';
-import {
-  isInternalURL,
-  getParentUrl,
-  flattenToAppURL,
-} from '@plone/volto/helpers';
-import config from '@plone/volto/registry';
+import Body from './Body.jsx';
 
 const messages = defineMessages({
   VideoFormDescription: {
@@ -146,12 +141,6 @@ class Edit extends Component {
     const placeholder =
       this.props.data.placeholder ||
       this.props.intl.formatMessage(messages.VideoBlockInputPlaceholder);
-
-    const allowsExternals =
-      data.allowExternals !== undefined
-        ? !!data.allowExternals
-        : !!config.settings.videoAllowExternalsDefault;
-
     return (
       <div
         className={cx(
@@ -164,159 +153,7 @@ class Edit extends Component {
         )}
       >
         {data.url ? (
-          <div
-            className={cx('video-inner', {
-              'full-width': this.props.data.align === 'full',
-            })}
-          >
-            {data.url.match('youtu') ? (
-              <>
-                {data.url.match('list') ? (
-                  data.preview_image ? (
-                    <Embed
-                      url={`https://www.youtube.com/embed/videoseries?list=${
-                        data.url.match(/^.*\?list=(.*)$/)[1]
-                      }`}
-                      placeholder={
-                        isInternalURL(data.preview_image)
-                          ? `${flattenToAppURL(
-                              data.preview_image,
-                            )}/@@images/image`
-                          : data.preview_image
-                      }
-                      defaultActive
-                      autoplay={false}
-                    />
-                  ) : (
-                    <Embed
-                      url={`https://www.youtube.com/embed/videoseries?list=${
-                        data.url.match(/^.*\?list=(.*)$/)[1]
-                      }`}
-                      icon="play"
-                      defaultActive
-                      autoplay={false}
-                    />
-                  )
-                ) : data.preview_image ? (
-                  <Embed
-                    id={
-                      data.url.match(/.be\//)
-                        ? data.url.match(/^.*\.be\/(.*)/)[1]
-                        : data.url.match(/^.*\?v=(.*)$/)[1]
-                    }
-                    source="youtube"
-                    placeholder={
-                      isInternalURL(data.preview_image)
-                        ? `${flattenToAppURL(
-                            data.preview_image,
-                          )}/@@images/image`
-                        : data.preview_image
-                    }
-                    icon="play"
-                    autoplay={false}
-                  />
-                ) : (
-                  <Embed
-                    id={
-                      data.url.match(/.be\//)
-                        ? data.url.match(/^.*\.be\/(.*)/)[1]
-                        : data.url.match(/^.*\?v=(.*)$/)[1]
-                    }
-                    source="youtube"
-                    icon="play"
-                    defaultActive
-                    autoplay={false}
-                  />
-                )}
-              </>
-            ) : (
-              <>
-                <div className="ui blocker" />
-                {data.url.match('vimeo') ? (
-                  data.preview_image ? (
-                    <Embed
-                      id={data.url.match(/^.*\.com\/(.*)/)[1]}
-                      source="vimeo"
-                      placeholder={
-                        isInternalURL(data.preview_image)
-                          ? `${flattenToAppURL(
-                              data.preview_image,
-                            )}/@@images/image`
-                          : data.preview_image
-                      }
-                      icon="play"
-                      autoplay={false}
-                    />
-                  ) : (
-                    <Embed
-                      id={data.url.match(/^.*\.com\/(.*)/)[1]}
-                      source="vimeo"
-                      icon="play"
-                      defaultActive
-                      autoplay={false}
-                    />
-                  )
-                ) : (
-                  <>
-                    <div className="ui blocker" />
-                    {data.url.match('.mp4') ? (
-                      // eslint-disable-next-line jsx-a11y/media-has-caption
-                      <video
-                        src={
-                          isInternalURL(
-                            data.url.replace(
-                              getParentUrl(config.settings.apiPath),
-                              '',
-                            ),
-                          )
-                            ? `${data.url}/@@download/file`
-                            : data.url
-                        }
-                        controls
-                        poster={
-                          data.preview_image
-                            ? isInternalURL(data.preview_image)
-                              ? `${flattenToAppURL(
-                                  data.preview_image,
-                                )}/@@images/image`
-                              : data.preview_image
-                            : ''
-                        }
-                        type="video/mp4"
-                      />
-                    ) : data.url && allowsExternals ? (
-                      // eslint-disable-next-line jsx-a11y/media-has-caption
-                      <video
-                        src={data.url}
-                        controls
-                        poster={
-                          data.preview_image
-                            ? isInternalURL(data.preview_image)
-                              ? `${flattenToAppURL(
-                                  data.preview_image,
-                                )}/@@images/image`
-                              : data.preview_image
-                            : null
-                        }
-                        type="video/mp4"
-                      />
-                    ) : (
-                      <div>
-                        <Message>
-                          <center>
-                            <FormattedMessage
-                              id="Please enter a valid URL by deleting the block and adding a new video block."
-                              defaultMessage="Please enter a valid URL by deleting the block and adding a new video block."
-                            />
-                          </center>
-                        </Message>
-                      </div>
-                    )}
-                  </>
-                )}
-              </>
-            )}
-          </div>
+          <Body data={this.props.data} isEditMode={true} />
         ) : (
           <Message>
             <center>

--- a/src/customizations/volto/components/manage/Blocks/Video/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/View.jsx
@@ -1,25 +1,12 @@
 /**
  * View video block.
  * @module components/manage/Blocks/Video/View
- *
- * Customizations:
- * - support external sources for preview image
- * - added ConditionalEmbed
- * - add default previewImage from youtube or vimeo if not selected in sidebar
  */
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Embed } from 'semantic-ui-react';
+import Body from './Body.jsx';
 import cx from 'classnames';
-import {
-  isInternalURL,
-  getParentUrl,
-  flattenToAppURL,
-} from '@plone/volto/helpers';
-import { ConditionalEmbed } from 'volto-gdpr-privacy';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import config from '@plone/volto/registry';
 
 /**
  * View video block class.
@@ -27,59 +14,6 @@ import config from '@plone/volto/registry';
  * @extends Component
  */
 const View = ({ data }) => {
-  const allowsExternals =
-    data.allowExternals !== undefined
-      ? !!data.allowExternals
-      : !!config.settings.videoAllowExternalsDefault;
-
-  let placeholder = data.preview_image
-    ? isInternalURL(data.preview_image)
-      ? `${flattenToAppURL(data.preview_image)}/@@images/image`
-      : data.preview_image
-    : null;
-
-  if (!placeholder && data.url) {
-    if (data.url.match('youtu')) {
-      if (!placeholder) {
-        //load video preview image from youtube
-        const videoID = data.url
-          .match(/youtube\.com.*(\?v=|\/embed\/)(.{11})/)
-          .pop();
-        placeholder =
-          'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';
-      }
-    } else if (data.url.match('vimeo')) {
-      const videoID = data.url.match(/^.*\.com\/(.*)/)[1];
-      placeholder = 'https://vumbnail.com/' + videoID + '.jpg';
-    }
-  }
-
-  const ref = React.createRef();
-  const onKeyDown = (e) => {
-    if (e.nativeEvent.keyCode === 13) {
-      ref.current.handleClick();
-    }
-  };
-  const embedSettings = {
-    placeholder: placeholder,
-    icon: (
-      <div
-        className="icon-play"
-        role="button"
-        tabIndex={0}
-        title="Download and Play video"
-      >
-        <FontAwesomeIcon icon={['fas', 'play']} />
-      </div>
-    ),
-    defaultActive: false,
-    autoplay: false,
-    aspectRatio: '16:9',
-    tabIndex: 0,
-    onKeyPress: onKeyDown,
-    ref: ref,
-  };
-
   return (
     <div
       className={cx(
@@ -90,79 +24,7 @@ const View = ({ data }) => {
         data.align,
       )}
     >
-      {data.url && (
-        <div
-          className={cx('video-inner', {
-            'full-width': data.align === 'full',
-          })}
-        >
-          <ConditionalEmbed url={data.url}>
-            {data.url.match('youtu') ? (
-              <>
-                {data.url.match('list') ? (
-                  <Embed
-                    url={`https://www.youtube.com/embed/videoseries?list=${
-                      data.url.match(/^.*\?list=(.*)$/)[1]
-                    }`}
-                    {...embedSettings}
-                  />
-                ) : (
-                  <Embed
-                    id={
-                      data.url.match(/.be\//)
-                        ? data.url.match(/^.*\.be\/(.*)/)[1]
-                        : data.url.match(/^.*\?v=(.*)$/)[1]
-                    }
-                    source="youtube"
-                    {...embedSettings}
-                  />
-                )}
-              </>
-            ) : (
-              <>
-                {data.url.match('vimeo') ? (
-                  <Embed
-                    id={data.url.match(/^.*\.com\/(.*)/)[1]}
-                    source="vimeo"
-                    {...embedSettings}
-                  />
-                ) : (
-                  <>
-                    {data.url.match('.mp4') ? (
-                      // eslint-disable-next-line jsx-a11y/media-has-caption
-                      <video
-                        src={
-                          isInternalURL(
-                            data.url.replace(
-                              getParentUrl(config.settings.apiPath),
-                              '',
-                            ),
-                          )
-                            ? `${data.url}/@@download/file`
-                            : data.url
-                        }
-                        controls
-                        poster={placeholder}
-                        type="video/mp4"
-                      />
-                    ) : data.url && allowsExternals ? (
-                      // eslint-disable-next-line jsx-a11y/media-has-caption
-                      <video
-                        src={data.url}
-                        controls
-                        poster={placeholder}
-                        type="video/mp4"
-                      />
-                    ) : (
-                      <div className="invalidVideoFormat" />
-                    )}
-                  </>
-                )}
-              </>
-            )}
-          </ConditionalEmbed>
-        </div>
-      )}
+      <Body data={data} />
     </div>
   );
 };

--- a/src/customizations/volto/components/manage/Blocks/Video/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Video/View.jsx
@@ -5,6 +5,7 @@
  * Customizations:
  * - support external sources for preview image
  * - added ConditionalEmbed
+ * - add default previewImage from youtube or vimeo if not selected in sidebar
  */
 
 import React from 'react';
@@ -17,6 +18,7 @@ import {
   flattenToAppURL,
 } from '@plone/volto/helpers';
 import { ConditionalEmbed } from 'volto-gdpr-privacy';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import config from '@plone/volto/registry';
 
 /**
@@ -29,6 +31,54 @@ const View = ({ data }) => {
     data.allowExternals !== undefined
       ? !!data.allowExternals
       : !!config.settings.videoAllowExternalsDefault;
+
+  let placeholder = data.preview_image
+    ? isInternalURL(data.preview_image)
+      ? `${flattenToAppURL(data.preview_image)}/@@images/image`
+      : data.preview_image
+    : null;
+
+  if (!placeholder && data.url) {
+    if (data.url.match('youtu')) {
+      if (!placeholder) {
+        //load video preview image from youtube
+        const videoID = data.url
+          .match(/youtube\.com.*(\?v=|\/embed\/)(.{11})/)
+          .pop();
+        placeholder =
+          'https://img.youtube.com/vi/' + videoID + '/sddefault.jpg';
+      }
+    } else if (data.url.match('vimeo')) {
+      const videoID = data.url.match(/^.*\.com\/(.*)/)[1];
+      placeholder = 'https://vumbnail.com/' + videoID + '.jpg';
+    }
+  }
+
+  const ref = React.createRef();
+  const onKeyDown = (e) => {
+    if (e.nativeEvent.keyCode === 13) {
+      ref.current.handleClick();
+    }
+  };
+  const embedSettings = {
+    placeholder: placeholder,
+    icon: (
+      <div
+        className="icon-play"
+        role="button"
+        tabIndex={0}
+        title="Download and Play video"
+      >
+        <FontAwesomeIcon icon={['fas', 'play']} />
+      </div>
+    ),
+    defaultActive: false,
+    autoplay: false,
+    aspectRatio: '16:9',
+    tabIndex: 0,
+    onKeyPress: onKeyDown,
+    ref: ref,
+  };
 
   return (
     <div
@@ -50,48 +100,11 @@ const View = ({ data }) => {
             {data.url.match('youtu') ? (
               <>
                 {data.url.match('list') ? (
-                  data.preview_image ? (
-                    <Embed
-                      url={`https://www.youtube.com/embed/videoseries?list=${
-                        data.url.match(/^.*\?list=(.*)$/)[1]
-                      }`}
-                      placeholder={
-                        isInternalURL(data.preview_image)
-                          ? `${flattenToAppURL(
-                              data.preview_image,
-                            )}/@@images/image`
-                          : data.preview_image
-                      }
-                      defaultActive
-                      autoplay={false}
-                    />
-                  ) : (
-                    <Embed
-                      url={`https://www.youtube.com/embed/videoseries?list=${
-                        data.url.match(/^.*\?list=(.*)$/)[1]
-                      }`}
-                      icon="play"
-                      defaultActive
-                      autoplay={false}
-                    />
-                  )
-                ) : data.preview_image ? (
                   <Embed
-                    id={
-                      data.url.match(/.be\//)
-                        ? data.url.match(/^.*\.be\/(.*)/)[1]
-                        : data.url.match(/^.*\?v=(.*)$/)[1]
-                    }
-                    source="youtube"
-                    placeholder={
-                      isInternalURL(data.preview_image)
-                        ? `${flattenToAppURL(
-                            data.preview_image,
-                          )}/@@images/image`
-                        : data.preview_image
-                    }
-                    icon="play"
-                    autoplay={false}
+                    url={`https://www.youtube.com/embed/videoseries?list=${
+                      data.url.match(/^.*\?list=(.*)$/)[1]
+                    }`}
+                    {...embedSettings}
                   />
                 ) : (
                   <Embed
@@ -101,38 +114,18 @@ const View = ({ data }) => {
                         : data.url.match(/^.*\?v=(.*)$/)[1]
                     }
                     source="youtube"
-                    icon="play"
-                    defaultActive
-                    autoplay={false}
+                    {...embedSettings}
                   />
                 )}
               </>
             ) : (
               <>
                 {data.url.match('vimeo') ? (
-                  data.preview_image ? (
-                    <Embed
-                      id={data.url.match(/^.*\.com\/(.*)/)[1]}
-                      source="vimeo"
-                      placeholder={
-                        isInternalURL(data.preview_image)
-                          ? `${flattenToAppURL(
-                              data.preview_image,
-                            )}/@@images/image`
-                          : data.preview_image
-                      }
-                      icon="play"
-                      autoplay={false}
-                    />
-                  ) : (
-                    <Embed
-                      id={data.url.match(/^.*\.com\/(.*)/)[1]}
-                      source="vimeo"
-                      icon="play"
-                      defaultActive
-                      autoplay={false}
-                    />
-                  )
+                  <Embed
+                    id={data.url.match(/^.*\.com\/(.*)/)[1]}
+                    source="vimeo"
+                    {...embedSettings}
+                  />
                 ) : (
                   <>
                     {data.url.match('.mp4') ? (
@@ -149,15 +142,7 @@ const View = ({ data }) => {
                             : data.url
                         }
                         controls
-                        poster={
-                          data.preview_image
-                            ? isInternalURL(data.preview_image)
-                              ? `${flattenToAppURL(
-                                  data.preview_image,
-                                )}/@@images/image`
-                              : data.preview_image
-                            : ''
-                        }
+                        poster={placeholder}
                         type="video/mp4"
                       />
                     ) : data.url && allowsExternals ? (
@@ -165,15 +150,7 @@ const View = ({ data }) => {
                       <video
                         src={data.url}
                         controls
-                        poster={
-                          data.preview_image
-                            ? isInternalURL(data.preview_image)
-                              ? `${flattenToAppURL(
-                                  data.preview_image,
-                                )}/@@images/image`
-                              : data.preview_image
-                            : null
-                        }
+                        poster={placeholder}
                         type="video/mp4"
                       />
                     ) : (

--- a/theme/ItaliaTheme/Blocks/_video.scss
+++ b/theme/ItaliaTheme/Blocks/_video.scss
@@ -1,0 +1,47 @@
+.block.video {
+  .ui.embed {
+    position: relative;
+
+    img.placeholder {
+      position: absolute;
+      top: 50%;
+      left: 0;
+      width: 100%;
+      transform: translateY(-50%);
+    }
+
+    .icon-play {
+      position: absolute;
+      z-index: 2;
+      top: 50%;
+      left: 50%;
+      width: 4rem;
+      height: 2.6rem;
+      background-color: rgba(0, 0, 0, 0.7);
+      border-radius: 15px;
+      color: $white;
+      cursor: pointer;
+      line-height: 2.6rem;
+      text-align: center;
+      transform: translateX(-50%) translateY(-50%);
+
+      svg {
+        width: 1.2rem;
+        height: 1.2rem;
+      }
+
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: $primary;
+        color: $primary-text;
+      }
+    }
+
+    &.active {
+      .icon-play {
+        display: none;
+      }
+    }
+  }
+}

--- a/theme/ItaliaTheme/Blocks/_videoGallery.scss
+++ b/theme/ItaliaTheme/Blocks/_videoGallery.scss
@@ -27,16 +27,60 @@
     margin-bottom: 1.5em;
 
     .ui.embed {
+      position: relative;
       width: auto;
       max-width: unset;
       height: unset;
-      padding: unset;
+      padding: 0 1em;
       background: transparent;
 
       > .embed {
         iframe {
           position: relative;
-          width: auto !important;
+          height: 190px;
+        }
+      }
+
+      img.placeholder {
+        width: 100%;
+        height: 190px;
+        object-fit: cover;
+      }
+
+      .icon-play {
+        position: absolute;
+        z-index: 2;
+
+        top: 50%;
+        left: 50%;
+        width: 3.6rem;
+        height: 2.5rem;
+        background-color: rgba(0, 0, 0, 0.7);
+        border-radius: 15px;
+
+        color: $white;
+        cursor: pointer;
+        line-height: 2.5rem;
+        text-align: center;
+        transform: translateX(-50%) translateY(-50%);
+
+        svg {
+          width: 1rem;
+          height: 1rem;
+        }
+
+        &:hover,
+        &:active,
+        &:focus {
+          background-color: $primary;
+          color: $primary-text;
+        }
+      }
+
+      &.active {
+        .icon-play,
+        img.placeholder {
+          display: none;
         }
       }
     }

--- a/theme/ItaliaTheme/Views/_embeddedVideo.scss
+++ b/theme/ItaliaTheme/Views/_embeddedVideo.scss
@@ -1,0 +1,72 @@
+.embedded-video {
+  .ui.embed {
+    position: relative;
+    width: 100%;
+    max-width: unset;
+    height: auto;
+    padding: 0 1em;
+    background: transparent;
+
+    > .embed {
+      iframe {
+        position: relative;
+        height: 350px;
+      }
+    }
+
+    img.placeholder {
+      width: 100%;
+      height: 350px;
+      object-fit: cover;
+    }
+
+    @media (max-width: #{map-get($grid-breakpoints, md)}) {
+      > .embed {
+        iframe {
+          height: 250px;
+        }
+      }
+
+      img.placeholder {
+        height: 250px;
+      }
+    }
+
+    .icon-play {
+      position: absolute;
+      z-index: 2;
+
+      top: 50%;
+      left: 50%;
+      width: 3.6rem;
+      height: 2.5rem;
+      background-color: rgba(0, 0, 0, 0.7);
+      border-radius: 15px;
+
+      color: $white;
+      cursor: pointer;
+      line-height: 2.5rem;
+      text-align: center;
+      transform: translateX(-50%) translateY(-50%);
+
+      svg {
+        width: 1rem;
+        height: 1rem;
+      }
+
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: $primary;
+        color: $primary-text;
+      }
+    }
+
+    &.active {
+      .icon-play,
+      img.placeholder {
+        display: none;
+      }
+    }
+  }
+}

--- a/theme/site.scss
+++ b/theme/site.scss
@@ -76,6 +76,7 @@
 @import 'ItaliaTheme/Blocks/rssBlock';
 @import 'ItaliaTheme/Blocks/numbers';
 @import 'ItaliaTheme/Blocks/countdown';
+@import 'ItaliaTheme/Blocks/video';
 
 @import 'ItaliaTheme/Views/uo';
 @import 'ItaliaTheme/Views/evento';
@@ -90,6 +91,7 @@
 @import 'ItaliaTheme/Views/slider';
 @import 'ItaliaTheme/Views/faqFolder';
 @import 'ItaliaTheme/Views/folder';
+@import 'ItaliaTheme/Views/embeddedVideo';
 @import 'ItaliaTheme/Widgets/iconWidget';
 @import 'ItaliaTheme/Widgets/searchSectionsConfigurationWidget';
 @import 'ItaliaTheme/Widgets/blocksWidget';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,9 +1974,9 @@
     pofile "1.0.10"
     razzle "3.4.5"
 
-"@plone/volto@plone/volto#f435e097263b184873f4eb96cfb70af050fe4a26":
+"@plone/volto@plone/volto#fedfca2c894b0a288af2eff95ef9fc8d19a85eec":
   version "15.4.1"
-  resolved "https://codeload.github.com/plone/volto/tar.gz/f435e097263b184873f4eb96cfb70af050fe4a26"
+  resolved "https://codeload.github.com/plone/volto/tar.gz/fedfca2c894b0a288af2eff95ef9fc8d19a85eec"
   dependencies:
     "@babel/plugin-proposal-export-default-from" "7.10.4"
     "@babel/plugin-proposal-export-namespace-from" "7.10.4"


### PR DESCRIPTION
Ora i video vengono caricati in maniera 'Leggera'.
Ovvero, invece di mettere subito in pagina l'iframe, viene prima messa in pagina l'immagine di anteprima del video.
Al click sull'immagine di anteprima, viene iniettato in pagina l'html dell'iframe. 
Dopodichè (so che è un po' brutto ma non sono riuscita a fare altrimenti) bisogna cliccare nuovamente sull'iframe per far partire il video. 
Anche la navigazione con la tastiera non è fantastica. 
Ne ho parlato con Serena, e non c'è altra soluzione.. tra l'altro abbiamo visto che usa questa tecnica anche google sul sito di support..
Voi avete idee? 
