### PR TITLE
Wrap animation label form block

### DIFF
--- a/theme/ItaliaTheme/Blocks/_form.scss
+++ b/theme/ItaliaTheme/Blocks/_form.scss
@@ -1,37 +1,46 @@
 .public-ui {
   .block.form {
-    .form-group {
-      display: flex;
-      flex-direction: column;
+    @media (max-width: #{map-get($grid-breakpoints, md)}) {
+      .form-group {
+        display: flex;
+        flex-direction: column;
 
-      label {
-        @extend .active;
-        position: relative;
-
-        order: 1;
-        line-height: 1.3rem;
-        transform: none;
-        white-space: normal;
-
-        &.active {
+        label {
+          position: relative;
+          order: 1;
+          font-size: 0.777rem;
+          line-height: 1.375rem;
           transform: none;
+          transform: none;
+          white-space: normal;
+
+          &.active {
+            font-size: 0.777rem;
+            transform: none;
+          }
+        }
+
+        input,
+        textarea,
+        .form-input-file {
+          order: 2;
+        }
+
+        input[type='date'] ~ label {
+          font-size: 0.777rem;
+          transform: none;
+        }
+
+        small.form-text {
+          position: relative;
+          order: 3;
         }
       }
 
-      input,
-      textarea,
       .form-input-file {
-        order: 2;
-      }
-
-      input[type='date'] ~ label {
-        font-size: 0.777rem;
-        transform: none;
-      }
-
-      small.form-text {
-        position: relative;
-        order: 3;
+        .dropzone-placeholder {
+          margin-top: 0;
+        }
       }
     }
   }
@@ -71,7 +80,7 @@
     > label {
       position: unset;
       margin-bottom: 0;
-      line-height: 1.3rem;
+      line-height: 1.375rem;
       transform: unset;
       white-space: normal;
     }
@@ -93,7 +102,7 @@
       color: $select-label-color;
       font-size: $select-label-size;
       font-weight: $select-label-weight;
-      line-height: 1.3rem;
+      line-height: 1.375rem;
       transform: none;
       white-space: normal;
     }
@@ -109,8 +118,13 @@
       overflow: inherit;
       height: auto;
       margin: 1px 0;
-      line-height: 30px;
+      line-height: 1.875rem;
       white-space: normal;
+
+      @media (max-width: #{map-get($grid-breakpoints, md)}) {
+        font-size: 0.875rem;
+        line-height: 1.375rem;
+      }
     }
 
     .form-check-group {
@@ -161,10 +175,6 @@
 
     .dropzone-text {
       margin: 0;
-    }
-
-    .dropzone-placeholder {
-      margin-top: 0;
     }
 
     .image-preview {

--- a/theme/ItaliaTheme/Blocks/_form.scss
+++ b/theme/ItaliaTheme/Blocks/_form.scss
@@ -1,3 +1,42 @@
+.public-ui {
+  .block.form {
+    .form-group {
+      display: flex;
+      flex-direction: column;
+
+      label {
+        @extend .active;
+
+        order: 1;
+        position: relative;
+        transform: none;
+        white-space: normal;
+        line-height: 1.3rem;
+
+        &.active {
+          transform: none;
+        }
+      }
+
+      input,
+      textarea,
+      .form-input-file {
+        order: 2;
+      }
+
+      input[type='date'] ~ label {
+        font-size: 0.777rem;
+        // transform: translateY(-75%);
+      }
+
+      small.form-text {
+        order: 3;
+        position: relative;
+      }
+    }
+  }
+}
+
 .block.form {
   .block-description {
     margin-bottom: 1rem;
@@ -32,7 +71,6 @@
     > label {
       position: unset;
       margin-bottom: 0;
-      line-height: 1rem;
       line-height: 1.3rem;
       transform: unset;
       white-space: normal;
@@ -98,11 +136,6 @@
     }
   }
 
-  .form-group input[type='date'] ~ label {
-    font-size: 0.777rem;
-    transform: translateY(-75%);
-  }
-
   textarea {
     border: 1px solid rgba(1, 1, 1, 0.1);
 
@@ -123,6 +156,10 @@
 
     .dropzone-text {
       margin: 0;
+    }
+
+    .dropzone-placeholder {
+      margin-top: 0;
     }
 
     .image-preview {

--- a/theme/ItaliaTheme/Blocks/_form.scss
+++ b/theme/ItaliaTheme/Blocks/_form.scss
@@ -6,12 +6,12 @@
 
       label {
         @extend .active;
+        position: relative;
 
         order: 1;
-        position: relative;
+        line-height: 1.3rem;
         transform: none;
         white-space: normal;
-        line-height: 1.3rem;
 
         &.active {
           transform: none;
@@ -26,12 +26,12 @@
 
       input[type='date'] ~ label {
         font-size: 0.777rem;
-        // transform: translateY(-75%);
+        transform: none;
       }
 
       small.form-text {
-        order: 3;
         position: relative;
+        order: 3;
       }
     }
   }
@@ -134,6 +134,11 @@
         }
       }
     }
+  }
+
+  .form-group input[type='date'] ~ label {
+    font-size: 0.777rem;
+    transform: translateY(-75%);
   }
 
   textarea {


### PR DESCRIPTION
Le label dinamiche dei form ora rimangono fisse sopra ai campi di input ed è stata rimossa l'interruzione di linea coi tre puntini di sospensione per permettere al testo di andare a capo

Label nowrap
![label-no-wrap](https://user-images.githubusercontent.com/43245702/169023160-799d97dc-267b-4a33-9da3-97c0980df404.png)
 
Label con la modifica
![label-wrapped](https://user-images.githubusercontent.com/43245702/169023288-9ca4c52d-903a-4b4d-b913-116b942ca82a.png)

