### PR TITLE
fix: removed focus from simple and image card blocks to fix draftjs link

### DIFF
--- a/src/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block.jsx
@@ -176,9 +176,6 @@ const Block = ({
                     onClick={() => {
                       setSelected('content');
                     }}
-                    onFocus={() => {
-                      setSelected('content');
-                    }}
                   >
                     <CardText
                       className="simple-text-card text"
@@ -197,9 +194,6 @@ const Block = ({
                         onSelectBlock={onSelectBlock}
                         onAddBlock={onAddBlock}
                         prevFocus="title"
-                        setFocus={(f) => {
-                          setSelected(f);
-                        }}
                         index={index}
                         disableMoveToNearest={true}
                       />

--- a/src/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/CardWithImage/Block.jsx
@@ -97,16 +97,8 @@ const Block = ({
           if (!selected) {
             onAddBlock('text', index + 1);
           }
-
           if (titleRef.current.contains(e.target)) {
             setSelected('content');
-          }
-        }
-      }}
-      onClick={(e) => {
-        if (inEditMode) {
-          if (wrapperRef.current.contains(e.target)) {
-            setSelected(null);
           }
         }
       }}
@@ -176,6 +168,9 @@ const Block = ({
                     onClick={() => {
                       setSelected('content');
                     }}
+                    onFocus={() => {
+                      setSelected('content');
+                    }}
                   >
                     <CardText
                       className="simple-text-card text"
@@ -195,6 +190,9 @@ const Block = ({
                         onAddBlock={onAddBlock}
                         prevFocus="title"
                         index={index}
+                        setFocus={(f) => {
+                          setSelected(f);
+                        }}
                         disableMoveToNearest={true}
                       />
                     </CardText>

--- a/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block.jsx
@@ -141,9 +141,6 @@ const Block = ({
                   onClick={() => {
                     setSelected('content');
                   }}
-                  onFocus={() => {
-                    setSelected('content');
-                  }}
                 >
                   <CardText>
                     <TextEditorWidget
@@ -162,9 +159,6 @@ const Block = ({
                       onAddBlock={onAddBlock}
                       index={index}
                       prevFocus="title"
-                      setFocus={(f) => {
-                        setSelected(f);
-                      }}
                       disableMoveToNearest={true}
                     />
                   </CardText>

--- a/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block.jsx
+++ b/src/components/ItaliaTheme/Blocks/TextCard/SimpleCard/Block.jsx
@@ -65,17 +65,7 @@ const Block = ({
   });
 
   return (
-    <div
-      className="simple-text-card-wrapper"
-      ref={wrapperRef}
-      onClick={(e) => {
-        if (inEditMode) {
-          if (wrapperRef.current.contains(e.target)) {
-            setSelected(null);
-          }
-        }
-      }}
-    >
+    <div className="simple-text-card-wrapper" ref={wrapperRef}>
       <Card
         color="white"
         className=" card-bg rounded"
@@ -90,7 +80,6 @@ const Block = ({
             ) {
               onAddBlock('text', index + 1);
             }
-
             if (titleRef.current.contains(e.target)) {
               setSelected('content');
             }
@@ -141,6 +130,9 @@ const Block = ({
                   onClick={() => {
                     setSelected('content');
                   }}
+                  onFocus={() => {
+                    setSelected('content');
+                  }}
                 >
                   <CardText>
                     <TextEditorWidget
@@ -159,6 +151,9 @@ const Block = ({
                       onAddBlock={onAddBlock}
                       index={index}
                       prevFocus="title"
+                      setFocus={(f) => {
+                        setSelected(f);
+                      }}
                       disableMoveToNearest={true}
                     />
                   </CardText>


### PR DESCRIPTION
Rimosso il focus nel testo dai blocchi card semplice e con immagine che creava un bug alla creazione di un link nel testo di draft js