### PR TITLE
fix: fixed width and height of slider images

### DIFF
--- a/theme/ItaliaTheme/Blocks/_sliderTemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_sliderTemplate.scss
@@ -106,23 +106,14 @@
           height: 400px;
           margin: 0;
 
-          .volto-image.responsive img {
-            width: auto;
-          }
-
-          picture {
-            position: absolute;
-            top: 50%;
-            width: 100%;
-            transform: translateY(-50%);
-          }
-
           img {
             min-width: 100%;
             min-height: 400px;
-            margin-left: 50%;
-            //width: auto;
-            transform: translateX(-50%);
+          }
+
+          .volto-image.responsive img,
+          img {
+            object-fit: cover;
           }
 
           figcaption {


### PR DESCRIPTION
Sistemato regole per riempire orizzontalmente e verticalmente lo slider senza stracciare e tagliare troppo le immagini

![screenshot-slider-update](https://user-images.githubusercontent.com/43245702/187716568-506936f5-7bc7-436d-aa27-3a922ccd34f3.png)
