### PR TITLE
fix: fixed description alignment of photogallery listing template

### DIFF
--- a/theme/ItaliaTheme/Blocks/_photogallerytemplate.scss
+++ b/theme/ItaliaTheme/Blocks/_photogallerytemplate.scss
@@ -18,11 +18,15 @@
 
   figure.img-wrapper {
     display: flex;
-    height: 300px;
-    max-height: 300px;
-    align-items: center;
+    flex-direction: column;
+    justify-content: center;
     margin-right: auto;
     margin-left: auto;
+
+    picture.volto-image.responsive {
+      height: 300px;
+      max-height: 300px;
+    }
 
     img {
       width: 100%;
@@ -90,7 +94,7 @@
 
   .slick-track {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
   }
 
   @media (max-width: #{map-get($grid-breakpoints, md)}) {


### PR DESCRIPTION
Risolto un bug che non mandava a capo la descrizione del template elenco photogallery