### PR TITLE
fix: fixed dates of cardCalendar component

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/Commons/CardCalendar.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/Commons/CardCalendar.jsx
@@ -18,35 +18,39 @@ const messages = defineMessages({
 export const CardCalendar = ({ start, end }) => {
   const intl = useIntl();
 
-  const _start = viewDate(intl.locale, start);
-  const _end = viewDate(intl.locale, end);
+  const _start = start && viewDate(intl.locale, start);
+  const _end = end && viewDate(intl.locale, end);
 
-  if (_start.isSame(_end, 'day')) {
-    return (
-      <div className="card-calendar d-flex flex-column justify-content-center">
-        <span className="card-date">{_start.format('D')}</span>
-        <span className="card-day">{_end.format('MMMM')}</span>
-      </div>
-    );
-  } else {
-    return (
-      <div className="custom-calendar-card">
+  if (_start && _end) {
+    if (_start.isSame(_end, 'day')) {
+      return (
         <div className="card-calendar d-flex flex-column justify-content-center">
-          <span className="card-date d-flex justify-content-center align-items-baseline">
-            <div className="date-label mr-1">
-              {intl.formatMessage(messages.from)}
-            </div>
-            <span className="date">{_start.format('DD/MM')}</span>
-          </span>
-          <span className="card-date d-flex justify-content-center align-items-baseline">
-            <div className="date-label mr-1">
-              {intl.formatMessage(messages.to)}
-            </div>
-            <span className="date">{_end.format('DD/MM')}</span>
-          </span>
+          <span className="card-date">{_start.format('D')}</span>
+          <span className="card-day">{_end.format('MMMM')}</span>
         </div>
-      </div>
-    );
+      );
+    } else {
+      return (
+        <div className="custom-calendar-card">
+          <div className="card-calendar d-flex flex-column justify-content-center">
+            <span className="card-date d-flex justify-content-center align-items-baseline">
+              <div className="date-label mr-1">
+                {intl.formatMessage(messages.from)}
+              </div>
+              <span className="date">{_start.format('DD/MM')}</span>
+            </span>
+            <span className="card-date d-flex justify-content-center align-items-baseline">
+              <div className="date-label mr-1">
+                {intl.formatMessage(messages.to)}
+              </div>
+              <span className="date">{_end.format('DD/MM')}</span>
+            </span>
+          </div>
+        </div>
+      );
+    }
+  } else {
+    return <></>;
   }
 };
 


### PR DESCRIPTION
Abbiamo trovato eventi che davano errore purché senza date, questa fix ci aiuta a priori ad evitare che si rompano i template elenco Card con Immagine e In evidenza