### PR TITLE
chore: description added to gallery image popup

### DIFF
--- a/src/components/ItaliaTheme/GalleryPreview/GalleryPreview.jsx
+++ b/src/components/ItaliaTheme/GalleryPreview/GalleryPreview.jsx
@@ -74,10 +74,12 @@ const GalleryPreview = ({ id, viewIndex, setViewIndex, items }) => {
             closeAriaLabel={intl.formatMessage(messages.close_preview)}
             toggle={closeModal}
           >
-            <h4>{items[viewIndex].title}</h4>
-            <p>{items[viewIndex].description}</p>
+            {items[viewIndex].title}
           </ModalHeader>
           <ModalBody>
+            {items[viewIndex].description && (
+              <p className="pb-3">{items[viewIndex].description}</p>
+            )}
             <div className="item-preview">
               {items.length > 1 && (
                 <Button

--- a/src/components/ItaliaTheme/GalleryPreview/GalleryPreview.jsx
+++ b/src/components/ItaliaTheme/GalleryPreview/GalleryPreview.jsx
@@ -74,7 +74,8 @@ const GalleryPreview = ({ id, viewIndex, setViewIndex, items }) => {
             closeAriaLabel={intl.formatMessage(messages.close_preview)}
             toggle={closeModal}
           >
-            {items[viewIndex].title}{' '}
+            <h4>{items[viewIndex].title}</h4>
+            <p>{items[viewIndex].description}</p>
           </ModalHeader>
           <ModalBody>
             <div className="item-preview">
@@ -93,7 +94,6 @@ const GalleryPreview = ({ id, viewIndex, setViewIndex, items }) => {
                   <Icon color="" icon="it-arrow-left" padding={false} />
                 </Button>
               )}
-
               <div className="image">
                 {items[viewIndex].image ? (
                   <img

--- a/theme/ItaliaTheme/Components/_galleryPreview.scss
+++ b/theme/ItaliaTheme/Components/_galleryPreview.scss
@@ -38,5 +38,8 @@
         }
       }
     }
+    .modal-body{
+      padding-top: 0.5rem;
+    }
   }
 }

--- a/theme/ItaliaTheme/Components/_galleryPreview.scss
+++ b/theme/ItaliaTheme/Components/_galleryPreview.scss
@@ -39,7 +39,7 @@
       }
     }
     .modal-body{
-      padding-top: 0.5rem;
+      padding-top: 0;
     }
   }
 }


### PR DESCRIPTION
Dentro il content type "Notizie e comunicati stampa", quando ci sono immagini dentro la cartella "Multimedia", queste sono mostrate in griglia su contenuto della notizia. Cliccando su un'immagine viene visualizzata un'anteprima. In questa modale è stato aggiunta la descrizione e identificato il titolo con una tag <H*>

<img width="1060" alt="Schermata 2022-10-24 alle 11 59 56" src="https://user-images.githubusercontent.com/60133113/198027413-b422aa53-7520-499e-9217-861467f42f6b.png">
