### PR TITLE
fix: conditional added to backgroundImage on single card

### DIFF
--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -52,9 +52,11 @@ const CardWithSlideUpTextTemplate = (props) => {
               <UniversalLink
                 item={!isEditMode ? item : null}
                 href={isEditMode ? '#' : null}
-                style={{
-                  backgroundImage: `url(${image})`,
-                }}
+                style={
+                  image && {
+                    backgroundImage: `url(${image})`,
+                  }
+                }
                 className="listing-item box bg-img"
                 key={index}
               >


### PR DESCRIPTION
Il blocco ritornava un console error quando un singolo card non aveva un'immagine di sfondo. È stato aggiunta una condizionale per verificare se l'immagine è presente.

[US#34694](https://redturtle.tpondemand.com/entity/34694-console-error-blocco-card-con-testo)