### PR TITLE
fix: person image inside card with image fixed

### DIFF
--- a/theme/ItaliaTheme/Blocks/_cardWithImageAndInEvidence.scss
+++ b/theme/ItaliaTheme/Blocks/_cardWithImageAndInEvidence.scss
@@ -92,4 +92,20 @@
       bottom: $v-gap * 3;
     }
   }
+  .card-persona {
+    .card-image-wrapper {
+      .card-body {
+        flex: 2;
+      }
+      .card-image {
+        overflow: hidden;
+        picture {
+          min-width: unset;
+          img {
+            object-fit: cover;
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
US34702
Ticket 34323

Dentro del blocco elenco tipo card con immagine, se sono filtrati "persone" e le persone hanno la stessa foto di profilo, o sia, la stessa persona 2 o più volte, però con contenuti diversi, le immagine diventavano diversi tra di loro se le opzioni del blocco sulla sidebar cambiano.

![image](https://user-images.githubusercontent.com/60133113/198586360-0da69d04-deb4-4b84-87a1-886d9a0e851e.png)

Con la sistemazione le immagine rimangono sempre con 1/3 della card senza variazione di altezza.

<img width="979" alt="Schermata 2022-10-28 alle 14 19 55" src="https://user-images.githubusercontent.com/60133113/198586013-ba2e0a98-b59e-4e15-8696-4cd1c337677d.png">
