### PR TITLE
chore: data element insertion - lighthouse id - block listing

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -245,7 +245,6 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: ID Lighthouse
 msgid "ID Lighthouse"
@@ -2109,12 +2108,12 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry2
 msgid "newEntry2"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry3
 msgid "newEntry3"
 msgstr ""
@@ -2865,6 +2864,11 @@ msgstr ""
 msgid "select_risultato"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service_category_link
+msgid "service_category_link"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
 # defaultMessage: Cos'è
 msgid "service_cos_e"
@@ -2899,11 +2903,6 @@ msgstr ""
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
-msgstr ""
-
-#: config/Blocks/ListingOptions/cardWithImageTemplate
-# defaultMessage: sevice_category_link
-msgid "sevice_category_link"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -250,6 +250,11 @@ msgstr ""
 msgid "ID Lighthouse"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: Identificativo di servizio a solo uso interno, utilizzato per le verifiche AgID inerenti al PNRR.
+msgid "ID Lighthouse Help Description"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -684,6 +689,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/Actions
 # defaultMessage: Vedi azioni
 msgid "actions"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: administration-element
+msgid "administration-element"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
@@ -2108,16 +2118,6 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry2
-msgid "newEntry2"
-msgstr ""
-
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry3
-msgid "newEntry3"
-msgstr ""
-
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2865,8 +2865,13 @@ msgid "select_risultato"
 msgstr ""
 
 #: config/Blocks/ListingOptions/utils
-# defaultMessage: service_category_link
-msgid "service_category_link"
+# defaultMessage: service-category-link
+msgid "service-category-link"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service-link
+msgid "service-link"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
@@ -3198,6 +3203,11 @@ msgstr ""
 #: helpers/ListingHelper
 # defaultMessage: al
 msgid "to"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: topic-element
+msgid "topic-element"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal

--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -245,6 +245,12 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: ID Lighthouse
+msgid "ID Lighthouse"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -2103,6 +2109,16 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry2
+msgid "newEntry2"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry3
+msgid "newEntry3"
+msgstr ""
+
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2883,6 +2899,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: sevice_category_link
+msgid "sevice_category_link"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -235,6 +235,11 @@ msgstr ""
 msgid "ID Lighthouse"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: Identificativo di servizio a solo uso interno, utilizzato per le verifiche AgID inerenti al PNRR.
+msgid "ID Lighthouse Help Description"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -670,6 +675,11 @@ msgstr ""
 # defaultMessage: Vedi azioni
 msgid "actions"
 msgstr "View actions"
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: administration-element
+msgid "administration-element"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 # defaultMessage: Vai alla ricerca per sezioni avanzata
@@ -2093,16 +2103,6 @@ msgstr "Alternative formats"
 msgid "natural_image_size"
 msgstr "Do not alter natural image sizes"
 
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry2
-msgid "newEntry2"
-msgstr ""
-
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry3
-msgid "newEntry3"
-msgstr ""
-
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2850,8 +2850,13 @@ msgid "select_risultato"
 msgstr ""
 
 #: config/Blocks/ListingOptions/utils
-# defaultMessage: service_category_link
-msgid "service_category_link"
+# defaultMessage: service-category-link
+msgid "service-category-link"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service-link
+msgid "service-link"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
@@ -3184,6 +3189,11 @@ msgstr "title"
 # defaultMessage: al
 msgid "to"
 msgstr "to"
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: topic-element
+msgid "topic-element"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 #: components/ItaliaTheme/Search/Search

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -230,7 +230,6 @@ msgstr "Hide all content types"
 msgid "Home"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: ID Lighthouse
 msgid "ID Lighthouse"
@@ -2094,12 +2093,12 @@ msgstr "Alternative formats"
 msgid "natural_image_size"
 msgstr "Do not alter natural image sizes"
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry2
 msgid "newEntry2"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry3
 msgid "newEntry3"
 msgstr ""
@@ -2850,6 +2849,11 @@ msgstr ""
 msgid "select_risultato"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service_category_link
+msgid "service_category_link"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
 # defaultMessage: Cos'è
 msgid "service_cos_e"
@@ -2885,11 +2889,6 @@ msgstr "Go to other search options"
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
 msgstr "Arrange on 4 columns"
-
-#: config/Blocks/ListingOptions/cardWithImageTemplate
-# defaultMessage: sevice_category_link
-msgid "sevice_category_link"
-msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing
 # defaultMessage: Condividi

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -230,6 +230,12 @@ msgstr "Hide all content types"
 msgid "Home"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: ID Lighthouse
+msgid "ID Lighthouse"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -2088,6 +2094,16 @@ msgstr "Alternative formats"
 msgid "natural_image_size"
 msgstr "Do not alter natural image sizes"
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry2
+msgid "newEntry2"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry3
+msgid "newEntry3"
+msgstr ""
+
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2869,6 +2885,11 @@ msgstr "Go to other search options"
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
 msgstr "Arrange on 4 columns"
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: sevice_category_link
+msgid "sevice_category_link"
+msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing
 # defaultMessage: Condividi

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -252,6 +252,11 @@ msgstr ""
 msgid "ID Lighthouse"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: Identificativo di servizio a solo uso interno, utilizzato per le verifiche AgID inerenti al PNRR.
+msgid "ID Lighthouse Help Description"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -687,6 +692,11 @@ msgstr ""
 # defaultMessage: Vedi azioni
 msgid "actions"
 msgstr "Voir les actions"
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: administration-element
+msgid "administration-element"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 # defaultMessage: Vai alla ricerca per sezioni avanzata
@@ -2110,16 +2120,6 @@ msgstr "Formats alternatifs"
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry2
-msgid "newEntry2"
-msgstr ""
-
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry3
-msgid "newEntry3"
-msgstr ""
-
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2867,8 +2867,13 @@ msgid "select_risultato"
 msgstr ""
 
 #: config/Blocks/ListingOptions/utils
-# defaultMessage: service_category_link
-msgid "service_category_link"
+# defaultMessage: service-category-link
+msgid "service-category-link"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service-link
+msgid "service-link"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
@@ -3201,6 +3206,11 @@ msgstr "titre"
 # defaultMessage: al
 msgid "to"
 msgstr "au"
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: topic-element
+msgid "topic-element"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 #: components/ItaliaTheme/Search/Search

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -247,7 +247,6 @@ msgstr "Masquer tous les types de contenu"
 msgid "Home"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: ID Lighthouse
 msgid "ID Lighthouse"
@@ -2111,12 +2110,12 @@ msgstr "Formats alternatifs"
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry2
 msgid "newEntry2"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry3
 msgid "newEntry3"
 msgstr ""
@@ -2867,6 +2866,11 @@ msgstr ""
 msgid "select_risultato"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service_category_link
+msgid "service_category_link"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
 # defaultMessage: Cos'è
 msgid "service_cos_e"
@@ -2902,11 +2906,6 @@ msgstr "Aller à d'autres options de recherche"
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
 msgstr "Disposer sur 4 colonnes"
-
-#: config/Blocks/ListingOptions/cardWithImageTemplate
-# defaultMessage: sevice_category_link
-msgid "sevice_category_link"
-msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing
 # defaultMessage: Condividi

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -247,6 +247,12 @@ msgstr "Masquer tous les types de contenu"
 msgid "Home"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: ID Lighthouse
+msgid "ID Lighthouse"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -2105,6 +2111,16 @@ msgstr "Formats alternatifs"
 msgid "natural_image_size"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry2
+msgid "newEntry2"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry3
+msgid "newEntry3"
+msgstr ""
+
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2886,6 +2902,11 @@ msgstr "Aller à d'autres options de recherche"
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
 msgstr "Disposer sur 4 colonnes"
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: sevice_category_link
+msgid "sevice_category_link"
+msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing
 # defaultMessage: Condividi

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -230,6 +230,12 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: ID Lighthouse
+msgid "ID Lighthouse"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -2088,6 +2094,16 @@ msgstr "Formati alternativi"
 msgid "natural_image_size"
 msgstr "Non alterare le dimensioni naturali dell'immagine"
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry2
+msgid "newEntry2"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry3
+msgid "newEntry3"
+msgstr ""
+
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2869,6 +2885,11 @@ msgstr ""
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
 msgstr "Disponi su 4 colonne"
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: sevice_category_link
+msgid "sevice_category_link"
+msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing
 # defaultMessage: Condividi

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -230,7 +230,6 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: ID Lighthouse
 msgid "ID Lighthouse"
@@ -2094,12 +2093,12 @@ msgstr "Formati alternativi"
 msgid "natural_image_size"
 msgstr "Non alterare le dimensioni naturali dell'immagine"
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry2
 msgid "newEntry2"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry3
 msgid "newEntry3"
 msgstr ""
@@ -2850,6 +2849,11 @@ msgstr ""
 msgid "select_risultato"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service_category_link
+msgid "service_category_link"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
 # defaultMessage: Cos'è
 msgid "service_cos_e"
@@ -2885,11 +2889,6 @@ msgstr ""
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
 msgstr "Disponi su 4 colonne"
-
-#: config/Blocks/ListingOptions/cardWithImageTemplate
-# defaultMessage: sevice_category_link
-msgid "sevice_category_link"
-msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing
 # defaultMessage: Condividi

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -235,6 +235,11 @@ msgstr ""
 msgid "ID Lighthouse"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: Identificativo di servizio a solo uso interno, utilizzato per le verifiche AgID inerenti al PNRR.
+msgid "ID Lighthouse Help Description"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -670,6 +675,11 @@ msgstr ""
 # defaultMessage: Vedi azioni
 msgid "actions"
 msgstr "Vedi azioni"
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: administration-element
+msgid "administration-element"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 # defaultMessage: Vai alla ricerca per sezioni avanzata
@@ -2093,16 +2103,6 @@ msgstr "Formati alternativi"
 msgid "natural_image_size"
 msgstr "Non alterare le dimensioni naturali dell'immagine"
 
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry2
-msgid "newEntry2"
-msgstr ""
-
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry3
-msgid "newEntry3"
-msgstr ""
-
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2850,8 +2850,13 @@ msgid "select_risultato"
 msgstr ""
 
 #: config/Blocks/ListingOptions/utils
-# defaultMessage: service_category_link
-msgid "service_category_link"
+# defaultMessage: service-category-link
+msgid "service-category-link"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service-link
+msgid "service-link"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
@@ -3184,6 +3189,11 @@ msgstr "titolo"
 # defaultMessage: al
 msgid "to"
 msgstr "al"
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: topic-element
+msgid "topic-element"
+msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
 #: components/ItaliaTheme/Search/Search

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -237,6 +237,12 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: ID Lighthouse
+msgid "ID Lighthouse"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -2095,6 +2101,16 @@ msgstr "<<<<<<< HEAD"
 msgid "natural_image_size"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry2
+msgid "newEntry2"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry3
+msgid "newEntry3"
+msgstr ""
+
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2875,6 +2891,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: sevice_category_link
+msgid "sevice_category_link"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -242,6 +242,11 @@ msgstr ""
 msgid "ID Lighthouse"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: Identificativo di servizio a solo uso interno, utilizzato per le verifiche AgID inerenti al PNRR.
+msgid "ID Lighthouse Help Description"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -676,6 +681,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/Actions
 # defaultMessage: Vedi azioni
 msgid "actions"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: administration-element
+msgid "administration-element"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
@@ -2100,16 +2110,6 @@ msgstr "<<<<<<< HEAD"
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry2
-msgid "newEntry2"
-msgstr ""
-
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry3
-msgid "newEntry3"
-msgstr ""
-
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2857,8 +2857,13 @@ msgid "select_risultato"
 msgstr ""
 
 #: config/Blocks/ListingOptions/utils
-# defaultMessage: service_category_link
-msgid "service_category_link"
+# defaultMessage: service-category-link
+msgid "service-category-link"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service-link
+msgid "service-link"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
@@ -3190,6 +3195,11 @@ msgstr ""
 #: helpers/ListingHelper
 # defaultMessage: al
 msgid "to"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: topic-element
+msgid "topic-element"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -237,7 +237,6 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: ID Lighthouse
 msgid "ID Lighthouse"
@@ -2101,12 +2100,12 @@ msgstr "<<<<<<< HEAD"
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry2
 msgid "newEntry2"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry3
 msgid "newEntry3"
 msgstr ""
@@ -2857,6 +2856,11 @@ msgstr ""
 msgid "select_risultato"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service_category_link
+msgid "service_category_link"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
 # defaultMessage: Cos'è
 msgid "service_cos_e"
@@ -2891,11 +2895,6 @@ msgstr ""
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
-msgstr ""
-
-#: config/Blocks/ListingOptions/cardWithImageTemplate
-# defaultMessage: sevice_category_link
-msgid "sevice_category_link"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -254,6 +254,11 @@ msgstr ""
 msgid "ID Lighthouse"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: Identificativo di servizio a solo uso interno, utilizzato per le verifiche AgID inerenti al PNRR.
+msgid "ID Lighthouse Help Description"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -688,6 +693,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/Actions
 # defaultMessage: Vedi azioni
 msgid "actions"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: administration-element
+msgid "administration-element"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
@@ -2112,16 +2122,6 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry2
-msgid "newEntry2"
-msgstr ""
-
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry3
-msgid "newEntry3"
-msgstr ""
-
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2869,8 +2869,13 @@ msgid "select_risultato"
 msgstr ""
 
 #: config/Blocks/ListingOptions/utils
-# defaultMessage: service_category_link
-msgid "service_category_link"
+# defaultMessage: service-category-link
+msgid "service-category-link"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service-link
+msgid "service-link"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
@@ -3202,6 +3207,11 @@ msgstr ""
 #: helpers/ListingHelper
 # defaultMessage: al
 msgid "to"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: topic-element
+msgid "topic-element"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -249,7 +249,6 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: ID Lighthouse
 msgid "ID Lighthouse"
@@ -2113,12 +2112,12 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry2
 msgid "newEntry2"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry3
 msgid "newEntry3"
 msgstr ""
@@ -2869,6 +2868,11 @@ msgstr ""
 msgid "select_risultato"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service_category_link
+msgid "service_category_link"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
 # defaultMessage: Cos'è
 msgid "service_cos_e"
@@ -2903,11 +2907,6 @@ msgstr ""
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
-msgstr ""
-
-#: config/Blocks/ListingOptions/cardWithImageTemplate
-# defaultMessage: sevice_category_link
-msgid "sevice_category_link"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -249,6 +249,12 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: ID Lighthouse
+msgid "ID Lighthouse"
+msgstr ""
+
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
 # defaultMessage: Seleziona le icone dalla barra a lato
 msgid "Icons placeholder"
@@ -2107,6 +2113,16 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry2
+msgid "newEntry2"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry3
+msgid "newEntry3"
+msgstr ""
+
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2887,6 +2903,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: sevice_category_link
+msgid "sevice_category_link"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2022-10-05T10:57:53.086Z\n"
+"POT-Creation-Date: 2022-10-31T11:06:37.786Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -230,6 +230,12 @@ msgstr ""
 #: components/ItaliaTheme/Breadcrumbs/Breadcrumbs
 # defaultMessage: Home
 msgid "Home"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: ID Lighthouse
+msgid "ID Lighthouse"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
@@ -2090,6 +2096,16 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry2
+msgid "newEntry2"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: newEntry3
+msgid "newEntry3"
+msgstr ""
+
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2870,6 +2886,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
+msgstr ""
+
+#: config/Blocks/ListingOptions/cardWithImageTemplate
+# defaultMessage: sevice_category_link
+msgid "sevice_category_link"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2022-10-31T11:06:37.786Z\n"
+"POT-Creation-Date: 2022-10-31T15:52:38.018Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -232,7 +232,6 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: ID Lighthouse
 msgid "ID Lighthouse"
@@ -2096,12 +2095,12 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry2
 msgid "newEntry2"
 msgstr ""
 
-#: config/Blocks/ListingOptions/cardWithImageTemplate
+#: config/Blocks/ListingOptions/utils
 # defaultMessage: newEntry3
 msgid "newEntry3"
 msgstr ""
@@ -2852,6 +2851,11 @@ msgstr ""
 msgid "select_risultato"
 msgstr ""
 
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service_category_link
+msgid "service_category_link"
+msgstr ""
+
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
 # defaultMessage: Cos'è
 msgid "service_cos_e"
@@ -2886,11 +2890,6 @@ msgstr ""
 #: config/Blocks/ListingOptions/cardWithImageTemplate
 # defaultMessage: Disponi su 4 colonne
 msgid "set_four_columns"
-msgstr ""
-
-#: config/Blocks/ListingOptions/cardWithImageTemplate
-# defaultMessage: sevice_category_link
-msgid "sevice_category_link"
 msgstr ""
 
 #: components/ItaliaTheme/View/Commons/Sharing

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2022-10-31T15:52:38.018Z\n"
+"POT-Creation-Date: 2022-11-02T10:44:36.493Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -235,6 +235,11 @@ msgstr ""
 #: config/Blocks/ListingOptions/utils
 # defaultMessage: ID Lighthouse
 msgid "ID Lighthouse"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: Identificativo di servizio a solo uso interno, utilizzato per le verifiche AgID inerenti al PNRR.
+msgid "ID Lighthouse Help Description"
 msgstr ""
 
 #: components/ItaliaTheme/Blocks/NumbersBlock/Edit
@@ -671,6 +676,11 @@ msgstr ""
 #: components/ItaliaTheme/View/Commons/Actions
 # defaultMessage: Vedi azioni
 msgid "actions"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: administration-element
+msgid "administration-element"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal
@@ -2095,16 +2105,6 @@ msgstr ""
 msgid "natural_image_size"
 msgstr ""
 
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry2
-msgid "newEntry2"
-msgstr ""
-
-#: config/Blocks/ListingOptions/utils
-# defaultMessage: newEntry3
-msgid "newEntry3"
-msgstr ""
-
 #: components/ItaliaTheme/View/NewsItemView/NewsItemText
 # defaultMessage: Contenuto
 msgid "news_item_contenuto"
@@ -2852,8 +2852,13 @@ msgid "select_risultato"
 msgstr ""
 
 #: config/Blocks/ListingOptions/utils
-# defaultMessage: service_category_link
-msgid "service_category_link"
+# defaultMessage: service-category-link
+msgid "service-category-link"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: service-link
+msgid "service-link"
 msgstr ""
 
 #: components/ItaliaTheme/View/ServizioView/ServizioCosE
@@ -3185,6 +3190,11 @@ msgstr ""
 #: helpers/ListingHelper
 # defaultMessage: al
 msgid "to"
+msgstr ""
+
+#: config/Blocks/ListingOptions/utils
+# defaultMessage: topic-element
+msgid "topic-element"
 msgstr ""
 
 #: components/ItaliaTheme/Header/HeaderSearch/SearchModal

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -131,7 +131,7 @@ const CardWithImageTemplate = (props) => {
                         <UniversalLink
                           item={!isEditMode ? item : null}
                           href={isEditMode ? '#' : ''}
-                          data-element={id_lighthouse && id_lighthouse}
+                          data-element={id_lighthouse}
                         >
                           {item.title || item.id}
                         </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithImageTemplate.jsx
@@ -46,6 +46,7 @@ const CardWithImageTemplate = (props) => {
     show_topics = true,
     hide_dates = false,
     natural_image_size = false,
+    id_lighthouse,
   } = props;
 
   const imagesToShow = set_four_columns ? 4 : 3;
@@ -130,6 +131,7 @@ const CardWithImageTemplate = (props) => {
                         <UniversalLink
                           item={!isEditMode ? item : null}
                           href={isEditMode ? '#' : ''}
+                          data-element={id_lighthouse && id_lighthouse}
                         >
                           {item.title || item.id}
                         </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -58,7 +58,7 @@ const CardWithSlideUpTextTemplate = (props) => {
                 }}
                 className="listing-item box bg-img"
                 key={index}
-                data-element={id_lighthouse && id_lighthouse}
+                data-element={id_lighthouse}
               >
                 <div className="bg-gradient"></div>
                 {(category || date) && (

--- a/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CardWithSlideUpTextTemplate.jsx
@@ -36,6 +36,7 @@ const CardWithSlideUpTextTemplate = (props) => {
     show_section,
     show_description = true,
     hide_dates = false,
+    id_lighthouse,
   } = props;
 
   return (
@@ -57,6 +58,7 @@ const CardWithSlideUpTextTemplate = (props) => {
                 }}
                 className="listing-item box bg-img"
                 key={index}
+                data-element={id_lighthouse && id_lighthouse}
               >
                 <div className="bg-gradient"></div>
                 {(category || date) && (

--- a/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
@@ -20,6 +20,7 @@ const CompleteBlockLinksTemplate = ({
   linkHref,
   show_block_bg,
   show_description = true,
+  id_lighthouse,
 }) => {
   return (
     <div className="complete-block-links-template">
@@ -46,6 +47,7 @@ const CompleteBlockLinksTemplate = ({
                   <UniversalLink
                     item={!isEditMode ? item : null}
                     href={isEditMode ? '#' : null}
+                    data-element={id_lighthouse && id_lighthouse}
                   >
                     <div className="d-flex">
                       {image && <div className="image-container">{image}</div>}

--- a/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/CompleteBlockLinksTemplate.jsx
@@ -47,7 +47,7 @@ const CompleteBlockLinksTemplate = ({
                   <UniversalLink
                     item={!isEditMode ? item : null}
                     href={isEditMode ? '#' : null}
-                    data-element={id_lighthouse && id_lighthouse}
+                    data-element={id_lighthouse}
                   >
                     <div className="d-flex">
                       {image && <div className="image-container">{image}</div>}

--- a/src/components/ItaliaTheme/Blocks/Listing/ContentInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/ContentInEvidenceTemplate.jsx
@@ -73,7 +73,7 @@ const ContentInEvidenceTemplate = ({
                     <CardTitle tag="h2">
                       <UniversalLink
                         href={flattenToAppURL(item['@id'])}
-                        data-element={id_lighthouse && id_lighthouse}
+                        data-element={id_lighthouse}
                       >
                         {item.title}
                       </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/ContentInEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/ContentInEvidenceTemplate.jsx
@@ -32,6 +32,7 @@ const ContentInEvidenceTemplate = ({
   show_block_bg,
   linkTitle,
   linkHref,
+  id_lighthouse,
 }) => {
   return (
     <div className="contentInEvidenceTemplate">
@@ -70,7 +71,10 @@ const ContentInEvidenceTemplate = ({
                       />
                     </CardCategory>
                     <CardTitle tag="h2">
-                      <UniversalLink href={flattenToAppURL(item['@id'])}>
+                      <UniversalLink
+                        href={flattenToAppURL(item['@id'])}
+                        data-element={id_lighthouse && id_lighthouse}
+                      >
                         {item.title}
                       </UniversalLink>
                     </CardTitle>

--- a/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -112,7 +112,7 @@ const InEvidenceTemplate = (props) => {
                     <UniversalLink
                       item={!isEditMode ? item : null}
                       href={isEditMode ? '#' : null}
-                      data-element={id_lighthouse && id_lighthouse}
+                      data-element={id_lighthouse}
                     >
                       {item.title || item.id}
                     </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/InEvidenceTemplate.jsx
@@ -44,6 +44,7 @@ const InEvidenceTemplate = (props) => {
     hide_dates,
     linkTitle,
     linkHref,
+    id_lighthouse,
   } = props;
 
   return (
@@ -111,6 +112,7 @@ const InEvidenceTemplate = (props) => {
                     <UniversalLink
                       item={!isEditMode ? item : null}
                       href={isEditMode ? '#' : null}
+                      data-element={id_lighthouse && id_lighthouse}
                     >
                       {item.title || item.id}
                     </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -51,6 +51,7 @@ const RibbonCardTemplate = (props) => {
     show_description = true,
     show_type,
     hide_dates,
+    id_lighthouse,
   } = props;
 
   return (
@@ -110,6 +111,7 @@ const RibbonCardTemplate = (props) => {
                       <UniversalLink
                         item={!isEditMode ? item : null}
                         href={isEditMode ? '#' : null}
+                        data-element={id_lighthouse && id_lighthouse}
                       >
                         {itemTitle}
                       </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/RibbonCardTemplate.jsx
@@ -111,7 +111,7 @@ const RibbonCardTemplate = (props) => {
                       <UniversalLink
                         item={!isEditMode ? item : null}
                         href={isEditMode ? '#' : null}
-                        data-element={id_lighthouse && id_lighthouse}
+                        data-element={id_lighthouse}
                       >
                         {itemTitle}
                       </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
@@ -24,6 +24,7 @@ const SimpleCardTemplateCompact = ({
   show_icon = true,
   show_block_bg,
   title,
+  id_lighthouse,
 }) => {
   return (
     <div className="simple-card-compact-template">
@@ -52,6 +53,7 @@ const SimpleCardTemplateCompact = ({
                 <UniversalLink
                   item={!isEditMode ? item : null}
                   href={isEditMode ? '#' : null}
+                  data-element={id_lighthouse && id_lighthouse}
                 >
                   {item.title || item.id}
                 </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateCompact.jsx
@@ -53,7 +53,7 @@ const SimpleCardTemplateCompact = ({
                 <UniversalLink
                   item={!isEditMode ? item : null}
                   href={isEditMode ? '#' : null}
-                  data-element={id_lighthouse && id_lighthouse}
+                  data-element={id_lighthouse}
                 >
                   {item.title || item.id}
                 </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -53,6 +53,7 @@ const SimpleCardTemplateDefault = (props) => {
     show_path_filters,
     addFilters,
     additionalFilters = [],
+    id_lighthouse,
   } = props;
 
   let currentPathFilter = additionalFilters
@@ -190,6 +191,7 @@ const SimpleCardTemplateDefault = (props) => {
                   <UniversalLink
                     item={!isEditMode ? item : null}
                     href={isEditMode ? '#' : null}
+                    data-element={id_lighthouse && id_lighthouse}
                   >
                     {itemTitle}
                   </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SimpleCard/SimpleCardTemplateDefault.jsx
@@ -191,7 +191,7 @@ const SimpleCardTemplateDefault = (props) => {
                   <UniversalLink
                     item={!isEditMode ? item : null}
                     href={isEditMode ? '#' : null}
-                    data-element={id_lighthouse && id_lighthouse}
+                    data-element={id_lighthouse}
                   >
                     {itemTitle}
                   </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/SquaresImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SquaresImageTemplate.jsx
@@ -34,7 +34,7 @@ const SquaresImageTemplate = ({
                 }}
                 className="listing-item box bg-img"
                 key={index}
-                data-element={id_lighthouse && id_lighthouse}
+                data-element={id_lighthouse}
               >
                 <span className="title font-weight-bold">{item?.title}</span>
               </UniversalLink>

--- a/src/components/ItaliaTheme/Blocks/Listing/SquaresImageTemplate.jsx
+++ b/src/components/ItaliaTheme/Blocks/Listing/SquaresImageTemplate.jsx
@@ -15,6 +15,7 @@ const SquaresImageTemplate = ({
   isEditMode,
   linkTitle,
   linkHref,
+  id_lighthouse,
 }) => {
   return (
     <div className="squares-image-template">
@@ -33,6 +34,7 @@ const SquaresImageTemplate = ({
                 }}
                 className="listing-item box bg-img"
                 key={index}
+                data-element={id_lighthouse && id_lighthouse}
               >
                 <span className="title font-weight-bold">{item?.title}</span>
               </UniversalLink>

--- a/src/config/Blocks/ListingOptions/cardWithImageTemplate.js
+++ b/src/config/Blocks/ListingOptions/cardWithImageTemplate.js
@@ -1,7 +1,10 @@
 import { defineMessages } from 'react-intl';
 
-import { templatesOptions } from '@italia/config/Blocks/ListingOptions';
-import { addSchemaField } from '@italia/config/Blocks/ListingOptions';
+import {
+  templatesOptions,
+  addDefaultOptions,
+} from '@italia/config/Blocks/ListingOptions';
+import { addLighthouseField } from '@italia/config/Blocks/ListingOptions/utils';
 
 const messages = defineMessages({
   always_show_image: {
@@ -20,22 +23,6 @@ const messages = defineMessages({
     id: 'set_four_columns',
     defaultMessage: 'Disponi su 4 colonne',
   },
-  sevice_category_link: {
-    id: 'sevice_category_link',
-    defaultMessage: 'sevice_category_link',
-  },
-  newEntry2: {
-    id: 'newEntry2',
-    defaultMessage: 'newEntry2',
-  },
-  newEntry3: {
-    id: 'newEntry3',
-    defaultMessage: 'newEntry3',
-  },
-  id_lighthouse: {
-    id: 'ID Lighthouse',
-    defaultMessage: 'ID Lighthouse',
-  },
 });
 
 export const addCardWithImageTemplateOptions = (
@@ -46,12 +33,15 @@ export const addCardWithImageTemplateOptions = (
 ) => {
   let pos = position;
 
+  pos = addLighthouseField(schema, intl, pos);
+
+  pos = addDefaultOptions(schema, formData, intl, pos);
+
   pos = templatesOptions(
     schema,
     formData,
     intl,
     [
-      'id_lighthouse',
       'always_show_image',
       'natural_image_size',
       'set_four_columns',
@@ -78,25 +68,6 @@ export const addCardWithImageTemplateOptions = (
       show_section: { default: false },
       hide_dates: { default: false },
       show_topics: { label: intl.formatMessage(messages.show_topics) },
-    },
-    pos,
-  );
-
-  addSchemaField(
-    schema,
-    'id_lighthouse',
-    intl.formatMessage(messages.id_lighthouse),
-    null,
-    {
-      choices: [
-        [
-          'sevice_category_link',
-          intl.formatMessage(messages.sevice_category_link),
-        ],
-        ['newEntry2', intl.formatMessage(messages.newEntry2)],
-        ['newEntry3', intl.formatMessage(messages.newEntry3)],
-      ],
-      /* default: 'medium', */
     },
     pos,
   );

--- a/src/config/Blocks/ListingOptions/cardWithImageTemplate.js
+++ b/src/config/Blocks/ListingOptions/cardWithImageTemplate.js
@@ -4,6 +4,7 @@ import {
   templatesOptions,
   addDefaultOptions,
 } from '@italia/config/Blocks/ListingOptions';
+
 import { addLighthouseField } from '@italia/config/Blocks/ListingOptions/utils';
 
 const messages = defineMessages({

--- a/src/config/Blocks/ListingOptions/cardWithImageTemplate.js
+++ b/src/config/Blocks/ListingOptions/cardWithImageTemplate.js
@@ -1,6 +1,7 @@
 import { defineMessages } from 'react-intl';
 
 import { templatesOptions } from '@italia/config/Blocks/ListingOptions';
+import { addSchemaField } from '@italia/config/Blocks/ListingOptions';
 
 const messages = defineMessages({
   always_show_image: {
@@ -19,6 +20,22 @@ const messages = defineMessages({
     id: 'set_four_columns',
     defaultMessage: 'Disponi su 4 colonne',
   },
+  sevice_category_link: {
+    id: 'sevice_category_link',
+    defaultMessage: 'sevice_category_link',
+  },
+  newEntry2: {
+    id: 'newEntry2',
+    defaultMessage: 'newEntry2',
+  },
+  newEntry3: {
+    id: 'newEntry3',
+    defaultMessage: 'newEntry3',
+  },
+  id_lighthouse: {
+    id: 'ID Lighthouse',
+    defaultMessage: 'ID Lighthouse',
+  },
 });
 
 export const addCardWithImageTemplateOptions = (
@@ -34,6 +51,7 @@ export const addCardWithImageTemplateOptions = (
     formData,
     intl,
     [
+      'id_lighthouse',
       'always_show_image',
       'natural_image_size',
       'set_four_columns',
@@ -63,5 +81,25 @@ export const addCardWithImageTemplateOptions = (
     },
     pos,
   );
+
+  addSchemaField(
+    schema,
+    'id_lighthouse',
+    intl.formatMessage(messages.id_lighthouse),
+    null,
+    {
+      choices: [
+        [
+          'sevice_category_link',
+          intl.formatMessage(messages.sevice_category_link),
+        ],
+        ['newEntry2', intl.formatMessage(messages.newEntry2)],
+        ['newEntry3', intl.formatMessage(messages.newEntry3)],
+      ],
+      /* default: 'medium', */
+    },
+    pos,
+  );
+
   return pos;
 };

--- a/src/config/Blocks/ListingOptions/cardWithSlideUpTextTemplate.js
+++ b/src/config/Blocks/ListingOptions/cardWithSlideUpTextTemplate.js
@@ -1,4 +1,9 @@
-import { templatesOptions } from '@italia/config/Blocks/ListingOptions';
+import {
+  templatesOptions,
+  addDefaultOptions,
+} from '@italia/config/Blocks/ListingOptions';
+
+import { addLighthouseField } from '@italia/config/Blocks/ListingOptions/utils';
 
 export const addCardWithSlideUpTextTemplateOptions = (
   schema,
@@ -7,6 +12,10 @@ export const addCardWithSlideUpTextTemplateOptions = (
   position = 0,
 ) => {
   let pos = position;
+
+  pos = addLighthouseField(schema, intl, pos);
+
+  pos = addDefaultOptions(schema, formData, intl, pos);
 
   pos = templatesOptions(
     schema,

--- a/src/config/Blocks/ListingOptions/completeBlockLinksTemplate.js
+++ b/src/config/Blocks/ListingOptions/completeBlockLinksTemplate.js
@@ -1,4 +1,9 @@
-import { templatesOptions } from '@italia/config/Blocks/ListingOptions';
+import {
+  templatesOptions,
+  addDefaultOptions,
+} from '@italia/config/Blocks/ListingOptions';
+
+import { addLighthouseField } from '@italia/config/Blocks/ListingOptions/utils';
 
 export const addCompleteBlockLinksTemplateOptions = (
   schema,
@@ -7,6 +12,10 @@ export const addCompleteBlockLinksTemplateOptions = (
   position = 0,
 ) => {
   let pos = position;
+
+  pos = addLighthouseField(schema, intl, pos);
+
+  pos = addDefaultOptions(schema, formData, intl, pos);
 
   pos = templatesOptions(
     schema,

--- a/src/config/Blocks/ListingOptions/inEvidenceTemplate.js
+++ b/src/config/Blocks/ListingOptions/inEvidenceTemplate.js
@@ -1,6 +1,11 @@
 import { defineMessages } from 'react-intl';
 
-import { templatesOptions } from '@italia/config/Blocks/ListingOptions';
+import {
+  templatesOptions,
+  addDefaultOptions,
+} from '@italia/config/Blocks/ListingOptions';
+
+import { addLighthouseField } from '@italia/config/Blocks/ListingOptions/utils';
 
 const messages = defineMessages({
   show_topics: {
@@ -16,6 +21,10 @@ export const addInEvidenceTemplateOptions = (
   position = 0,
 ) => {
   let pos = position;
+
+  pos = addLighthouseField(schema, intl, pos);
+
+  pos = addDefaultOptions(schema, formData, intl, pos);
 
   pos = templatesOptions(
     schema,

--- a/src/config/Blocks/ListingOptions/ribbonCardTemplate.js
+++ b/src/config/Blocks/ListingOptions/ribbonCardTemplate.js
@@ -1,6 +1,11 @@
 import { defineMessages } from 'react-intl';
 
-import { templatesOptions } from '@italia/config/Blocks/ListingOptions';
+import {
+  templatesOptions,
+  addDefaultOptions,
+} from '@italia/config/Blocks/ListingOptions';
+
+import { addLighthouseField } from '@italia/config/Blocks/ListingOptions/utils';
 
 const messages = defineMessages({
   show_only_first_ribbon: {
@@ -16,6 +21,10 @@ export const addRibbonCardTemplateOptions = (
   position = 0,
 ) => {
   let pos = position;
+
+  pos = addLighthouseField(schema, intl, pos);
+
+  pos = addDefaultOptions(schema, formData, intl, pos);
 
   pos = templatesOptions(
     schema,

--- a/src/config/Blocks/ListingOptions/simpleCardTemplate.js
+++ b/src/config/Blocks/ListingOptions/simpleCardTemplate.js
@@ -6,6 +6,8 @@ import {
   templatesOptions,
 } from '@italia/config/Blocks/ListingOptions';
 
+import { addLighthouseField } from '@italia/config/Blocks/ListingOptions/utils';
+
 const messages = defineMessages({
   appearance: {
     id: 'Aspetto',
@@ -32,6 +34,7 @@ export const addSimpleCardTemplateOptions = (
   position = 0,
 ) => {
   let pos = position;
+
   addSchemaField(
     schema,
     'appearance',
@@ -48,6 +51,8 @@ export const addSimpleCardTemplateOptions = (
     pos,
   );
   pos++;
+
+  pos = addLighthouseField(schema, intl, pos);
 
   pos = addDefaultOptions(schema, formData, intl, pos);
 

--- a/src/config/Blocks/ListingOptions/simpleCardTemplate.js
+++ b/src/config/Blocks/ListingOptions/simpleCardTemplate.js
@@ -35,6 +35,8 @@ export const addSimpleCardTemplateOptions = (
 ) => {
   let pos = position;
 
+  pos = addLighthouseField(schema, intl, pos);
+
   addSchemaField(
     schema,
     'appearance',
@@ -51,8 +53,6 @@ export const addSimpleCardTemplateOptions = (
     pos,
   );
   pos++;
-
-  pos = addLighthouseField(schema, intl, pos);
 
   pos = addDefaultOptions(schema, formData, intl, pos);
 

--- a/src/config/Blocks/ListingOptions/utils.js
+++ b/src/config/Blocks/ListingOptions/utils.js
@@ -50,20 +50,29 @@ const messages = defineMessages({
     defaultMessage: 'Filtro',
   },
   service_category_link: {
-    id: 'service_category_link',
-    defaultMessage: 'service_category_link',
+    id: 'service-category-link',
+    defaultMessage: 'service-category-link',
   },
-  newEntry2: {
-    id: 'newEntry2',
-    defaultMessage: 'newEntry2',
+  topic_element: {
+    id: 'topic-element',
+    defaultMessage: 'topic-element',
   },
-  newEntry3: {
-    id: 'newEntry3',
-    defaultMessage: 'newEntry3',
+  service_link: {
+    id: 'service-link',
+    defaultMessage: 'service-link',
+  },
+  administration_element: {
+    id: 'administration-element',
+    defaultMessage: 'administration-element',
   },
   id_lighthouse: {
     id: 'ID Lighthouse',
     defaultMessage: 'ID Lighthouse',
+  },
+  id_lighthouse_description: {
+    id: 'ID Lighthouse Help Description',
+    defaultMessage:
+      'Identificativo di servizio a solo uso interno, utilizzato per le verifiche AgID inerenti al PNRR.',
   },
 });
 
@@ -155,15 +164,19 @@ export const addLighthouseField = (schema, intl, position = 0) => {
     schema,
     'id_lighthouse',
     intl.formatMessage(messages.id_lighthouse),
-    null,
+    intl.formatMessage(messages.id_lighthouse_description),
     {
       choices: [
         [
-          'service_category_link',
+          'service-category-link',
           intl.formatMessage(messages.service_category_link),
         ],
-        ['newEntry2', intl.formatMessage(messages.newEntry2)],
-        ['newEntry3', intl.formatMessage(messages.newEntry3)],
+        ['topic-element', intl.formatMessage(messages.topic_element)],
+        ['service-link', intl.formatMessage(messages.service_link)],
+        [
+          'administration-element',
+          intl.formatMessage(messages.administration_element),
+        ],
       ],
       /* default: 'medium', */
     },

--- a/src/config/Blocks/ListingOptions/utils.js
+++ b/src/config/Blocks/ListingOptions/utils.js
@@ -49,6 +49,10 @@ const messages = defineMessages({
     id: 'Path filter filtro',
     defaultMessage: 'Filtro',
   },
+  id_lighthouse: {
+    id: 'ID Lighthouse',
+    defineMessages: 'ID Lighthouse',
+  },
 });
 
 export const addSchemaField = (

--- a/src/config/Blocks/ListingOptions/utils.js
+++ b/src/config/Blocks/ListingOptions/utils.js
@@ -49,22 +49,6 @@ const messages = defineMessages({
     id: 'Path filter filtro',
     defaultMessage: 'Filtro',
   },
-  service_category_link: {
-    id: 'service-category-link',
-    defaultMessage: 'service-category-link',
-  },
-  topic_element: {
-    id: 'topic-element',
-    defaultMessage: 'topic-element',
-  },
-  service_link: {
-    id: 'service-link',
-    defaultMessage: 'service-link',
-  },
-  administration_element: {
-    id: 'administration-element',
-    defaultMessage: 'administration-element',
-  },
   id_lighthouse: {
     id: 'ID Lighthouse',
     defaultMessage: 'ID Lighthouse',
@@ -167,16 +151,10 @@ export const addLighthouseField = (schema, intl, position = 0) => {
     intl.formatMessage(messages.id_lighthouse_description),
     {
       choices: [
-        [
-          'service-category-link',
-          intl.formatMessage(messages.service_category_link),
-        ],
-        ['topic-element', intl.formatMessage(messages.topic_element)],
-        ['service-link', intl.formatMessage(messages.service_link)],
-        [
-          'administration-element',
-          intl.formatMessage(messages.administration_element),
-        ],
+        ['service-category-link', 'service-category-link'],
+        ['topic-element', 'topic-element'],
+        ['service-link', 'service-link'],
+        ['administration-element', 'administration-element'],
       ],
       /* default: 'medium', */
     },

--- a/src/config/Blocks/ListingOptions/utils.js
+++ b/src/config/Blocks/ListingOptions/utils.js
@@ -49,9 +49,21 @@ const messages = defineMessages({
     id: 'Path filter filtro',
     defaultMessage: 'Filtro',
   },
+  service_category_link: {
+    id: 'service_category_link',
+    defaultMessage: 'service_category_link',
+  },
+  newEntry2: {
+    id: 'newEntry2',
+    defaultMessage: 'newEntry2',
+  },
+  newEntry3: {
+    id: 'newEntry3',
+    defaultMessage: 'newEntry3',
+  },
   id_lighthouse: {
     id: 'ID Lighthouse',
-    defineMessages: 'ID Lighthouse',
+    defaultMessage: 'ID Lighthouse',
   },
 });
 
@@ -132,6 +144,32 @@ export const templatesOptions = (
     }
     pos++;
   });
+
+  return pos;
+};
+
+export const addLighthouseField = (schema, intl, position = 0) => {
+  let pos = position;
+
+  addSchemaField(
+    schema,
+    'id_lighthouse',
+    intl.formatMessage(messages.id_lighthouse),
+    null,
+    {
+      choices: [
+        [
+          'service_category_link',
+          intl.formatMessage(messages.service_category_link),
+        ],
+        ['newEntry2', intl.formatMessage(messages.newEntry2)],
+        ['newEntry3', intl.formatMessage(messages.newEntry3)],
+      ],
+      /* default: 'medium', */
+    },
+    pos,
+  );
+  pos++;
 
   return pos;
 };

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -136,7 +136,8 @@ const italiaListingVariations = [
     template: SquaresImageTemplate,
     skeleton: SquaresImageTemplateSkeleton,
     schemaEnhancer: ({ schema, formData, intl }) => {
-      /*let pos = */ addDefaultOptions(schema, formData, intl);
+      let pos = addLighthouseField(schema, intl);
+      addDefaultOptions(schema, formData, intl, pos);
       return schema;
     },
   },

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -89,8 +89,7 @@ const italiaListingVariations = [
     template: InEvidenceTemplate,
     skeleton: InEvidenceTemplateSkeleton,
     schemaEnhancer: ({ schema, formData, intl }) => {
-      let pos = addDefaultOptions(schema, formData, intl);
-      addInEvidenceTemplateOptions(schema, formData, intl, pos);
+      addInEvidenceTemplateOptions(schema, formData, intl);
       return schema;
     },
   },

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -171,8 +171,7 @@ const italiaListingVariations = [
     template: CompleteBlockLinksTemplate,
     skeleton: CompleteBlockLinksTemplateSkeleton,
     schemaEnhancer: ({ schema, formData, intl }) => {
-      let pos = addDefaultOptions(schema, formData, intl);
-      addCompleteBlockLinksTemplateOptions(schema, formData, intl, pos);
+      addCompleteBlockLinksTemplateOptions(schema, formData, intl);
       return schema;
     },
   },

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -60,6 +60,8 @@ import {
   addPhotogalleryTemplateOptions,
 } from '@italia/config/Blocks/ListingOptions';
 
+import { addLighthouseField } from '@italia/config/Blocks/ListingOptions/utils';
+
 const italiaListingVariations = [
   {
     id: 'simpleCard',
@@ -100,7 +102,8 @@ const italiaListingVariations = [
     template: ContentInEvidenceTemplate,
     skeleton: ContentInEvidenceTemplateSkeleton,
     schemaEnhancer: ({ schema, formData, intl }) => {
-      /*let pos = */ addDefaultOptions(schema, formData, intl);
+      let pos = addLighthouseField(schema, intl);
+      addDefaultOptions(schema, formData, intl, pos);
       return schema;
     },
   },

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -78,8 +78,7 @@ const italiaListingVariations = [
     template: CardWithImageTemplate,
     skeleton: CardWithImageTemplateSkeleton,
     schemaEnhancer: ({ schema, formData, intl }) => {
-      let pos = addDefaultOptions(schema, formData, intl);
-      addCardWithImageTemplateOptions(schema, formData, intl, pos);
+      addCardWithImageTemplateOptions(schema, formData, intl);
       return schema;
     },
   },

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -125,8 +125,7 @@ const italiaListingVariations = [
     template: CardWithSlideUpTextTemplate,
     skeleton: CardWithSlideUpTextTemplateSkeleton,
     schemaEnhancer: ({ schema, formData, intl }) => {
-      let pos = addDefaultOptions(schema, formData, intl);
-      addCardWithSlideUpTextTemplateOptions(schema, formData, intl, pos);
+      addCardWithSlideUpTextTemplateOptions(schema, formData, intl);
       return schema;
     },
   },

--- a/src/config/Blocks/listingVariations.js
+++ b/src/config/Blocks/listingVariations.js
@@ -114,8 +114,7 @@ const italiaListingVariations = [
     template: RibbonCardTemplate,
     skeleton: RibbonCardTemplateSkeleton,
     schemaEnhancer: ({ schema, formData, intl }) => {
-      let pos = addDefaultOptions(schema, formData, intl);
-      addRibbonCardTemplateOptions(schema, formData, intl, pos);
+      addRibbonCardTemplateOptions(schema, formData, intl);
       return schema;
     },
   },


### PR DESCRIPTION
[Us#34658](https://redturtle.tpondemand.com/entity/34658-nei-blocchi-elenco-inserire-la-possibilita)

Nella sidebar dei blocchi elenco, è stato aggiunto un campo in cui si può scrivere scegliere un ID. Tale ID deve essere applicato dal personale RT come valore del data-element sul link delle card su blocchi elenco:

- Card semplice
- Card con immagine
- in evidenza
- Contenuto in evidenza
- Card con nastro
- Card con testo animato
- Quadratoni con immagine
- Blocco link completo

Il campo aggiunto è un select con:

- service-category-link
- topic-element
- service-link
- administration-element