### PR TITLE
feat: lighthouse - added data-element on MegaMenu component 

### DIFF
--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -75,7 +75,6 @@ const MegaMenu = ({ item, pathname }) => {
   const blocksFieldname = getBlocksFieldname(item);
   const blocksLayoutFieldname = getBlocksLayoutFieldname(item);
   const isItemActive = isActive(item, pathname);
-
   const [menuStatus, setMenuStatus] = useState(false);
 
   const getAnchorTarget = (nodeElement) => {
@@ -118,6 +117,7 @@ const MegaMenu = ({ item, pathname }) => {
           item={item.linkUrl[0]?.['@id'] ? item.linkUrl[0] : '#'}
           tag={UniversalLink}
           active={isItemActive}
+          data-element={item.id_lighthouse}
         >
           <span dangerouslySetInnerHTML={{ __html: item.title }}></span>
           {isItemActive && (
@@ -245,7 +245,13 @@ const MegaMenu = ({ item, pathname }) => {
           tag="div"
           toggle={() => setMenuStatus(!menuStatus)}
         >
-          <DropdownToggle aria-haspopup color="secondary" nav>
+          <DropdownToggle
+            aria-haspopup
+            color="secondary"
+            nav
+            data-element={item.id_lighthouse}
+            className="teste"
+          >
             <span dangerouslySetInnerHTML={{ __html: item.title }}></span>
             <Icon
               icon="it-expand"

--- a/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
+++ b/src/components/ItaliaTheme/MegaMenu/MegaMenu.jsx
@@ -250,7 +250,6 @@ const MegaMenu = ({ item, pathname }) => {
             color="secondary"
             nav
             data-element={item.id_lighthouse}
-            className="teste"
           >
             <span dangerouslySetInnerHTML={{ __html: item.title }}></span>
             <Icon

--- a/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -121,7 +121,7 @@ const Navigation = ({ pathname }) => {
                 </UniversalLink>
               </div>
               {/* Main Menu */}
-              <Nav navbar>
+              <Nav data-element="main-navigation" navbar>
                 {menu
                   ?.filter((item) => item.visible)
                   ?.map((item, index) => (


### PR DESCRIPTION
**_!important: volto-dropdownmenu needs to be updated with the new select field to works properly_**

volto-dropdownmenu branch related: lighthouse (not yet pushed, access needed)

[US35070](https://redturtle.tpondemand.com/entity/35070-adeguare-lhmtl-secondo-le-direttive-per)

Added a new field on dropdown-menu control pannel to set the tag data-element on every single menu item and in the list container (ul) which contains the entire menu.

List of choices for the select ID Lighthouse field:
- all-services
- management
- live
- news
- all-topics

For the list container: "main-navigation"