### PR TITLE
Lighthouse draftjs

### DIFF
--- a/src/config/RichTextEditor/ToolbarButtons/Lighthouse.jsx
+++ b/src/config/RichTextEditor/ToolbarButtons/Lighthouse.jsx
@@ -12,41 +12,41 @@ const AlignButtonComponent = (props) => {
       block_type: 'lighthouse_appointment-booking',
       value: createBlockStyleButton({
         blockType: 'lighthouse_appointment-booking',
-        children: '1-appointment-booking',
+        children: 'appointment-booking',
       }),
-      contentWhenSelected: '1',
+      contentWhenSelected: <Icon name={showSVG} size="24px" />,
     },
     {
       block_type: 'lighthouse_faq',
       value: createBlockStyleButton({
         blockType: 'lighthouse_faq',
-        children: '2-faq',
+        children: 'faq',
       }),
-      contentWhenSelected: '2',
+      contentWhenSelected: <Icon name={showSVG} size="24px" />,
     },
     {
       block_type: 'lighthouse_report-inefficency',
       value: createBlockStyleButton({
         blockType: 'lighthouse_report-inefficency',
-        children: '3-report-inefficency',
+        children: 'report-inefficency',
       }),
-      contentWhenSelected: '3',
+      contentWhenSelected: <Icon name={showSVG} size="24px" />,
     },
     {
       block_type: 'lighthouse_accessibility-link',
       value: createBlockStyleButton({
         blockType: 'lighthouse_accessibility-link',
-        children: '4-accessibility-link',
+        children: 'accessibility-link',
       }),
-      contentWhenSelected: '4',
+      contentWhenSelected: <Icon name={showSVG} size="24px" />,
     },
     {
       block_type: 'lighthouse_privacy-policy-link',
       value: createBlockStyleButton({
         blockType: 'lighthouse_privacy-policy-link',
-        children: '5-privacy-policy-link',
+        children: 'privacy-policy-link',
       }),
-      contentWhenSelected: '5',
+      contentWhenSelected: <Icon name={showSVG} size="24px" />,
     },
   ];
 

--- a/src/config/RichTextEditor/ToolbarButtons/Lighthouse.jsx
+++ b/src/config/RichTextEditor/ToolbarButtons/Lighthouse.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+import Icon from '@plone/volto/components/theme/Icon/Icon';
+import showSVG from '@plone/volto/icons/show.svg';
+
+import DraftJsDropdownButton from './DraftJsDropdownButton';
+
+const AlignButtonComponent = (props) => {
+  const createBlockStyleButton = props.draftJsCreateBlockStyleButton.default;
+  const options = [
+    {
+      block_type: 'lighthouse_appointment-booking',
+      value: createBlockStyleButton({
+        blockType: 'lighthouse_appointment-booking',
+        children: '1-appointment-booking',
+      }),
+      contentWhenSelected: '1',
+    },
+    {
+      block_type: 'lighthouse_faq',
+      value: createBlockStyleButton({
+        blockType: 'lighthouse_faq',
+        children: '2-faq',
+      }),
+      contentWhenSelected: '2',
+    },
+    {
+      block_type: 'lighthouse_report-inefficency',
+      value: createBlockStyleButton({
+        blockType: 'lighthouse_report-inefficency',
+        children: '3-report-inefficency',
+      }),
+      contentWhenSelected: '3',
+    },
+    {
+      block_type: 'lighthouse_accessibility-link',
+      value: createBlockStyleButton({
+        blockType: 'lighthouse_accessibility-link',
+        children: '4-accessibility-link',
+      }),
+      contentWhenSelected: '4',
+    },
+    {
+      block_type: 'lighthouse_privacy-policy-link',
+      value: createBlockStyleButton({
+        blockType: 'lighthouse_privacy-policy-link',
+        children: '5-privacy-policy-link',
+      }),
+      contentWhenSelected: '5',
+    },
+  ];
+
+  return (
+    <DraftJsDropdownButton
+      {...props}
+      optionsList={options}
+      content={<Icon name={showSVG} size="24px" />}
+    />
+  );
+};
+
+export const AlignButton = injectLazyLibs(['draftJsCreateBlockStyleButton'])(
+  AlignButtonComponent,
+);
+
+export default React.memo(AlignButton);

--- a/src/config/RichTextEditor/config.js
+++ b/src/config/RichTextEditor/config.js
@@ -11,6 +11,7 @@ import Blocks from '@plone/volto/config/RichTextEditor/Blocks';
 import UnderlineButton from '@italia/config/RichTextEditor/ToolbarButtons/UnderlineButton';
 import HeadingsButton from '@italia/config/RichTextEditor/ToolbarButtons/HeadingsButton';
 import AlignButton from '@italia/config/RichTextEditor/ToolbarButtons/AlignButton';
+import Lighthouse from '@italia/config/RichTextEditor/ToolbarButtons/Lighthouse';
 import CalloutsButton from '@italia/config/RichTextEditor/ToolbarButtons/CalloutsButton';
 import ButtonsButton from '@italia/config/RichTextEditor/ToolbarButtons/ButtonsButton';
 import TextSizeButton from '@italia/config/RichTextEditor/ToolbarButtons/TextSizeButton';
@@ -39,6 +40,8 @@ const ItaliaRichTextEditorInlineToolbarButtons = (props, plugins) => {
     ItalicButton,
     UnderlineButton(props),
     TextSizeButton(props),
+    Separator,
+    Lighthouse,
     Separator,
     HeadingsButton(props),
     linkPlugin.LinkButton,
@@ -72,6 +75,15 @@ const renderHTMLBlock = (child) => {
     }
   });
 };
+const renderDataElement = (element) => {
+  if (typeof document !== 'undefined') {
+    document.querySelector(`.lighthouse_${element} a`) &&
+      document
+        .querySelector(`.lighthouse_${element} a`)
+        .setAttribute('data-element', element);
+  }
+};
+
 const ItaliaBlocksHtmlRenderers = {
   blockquote: (children, { keys }) =>
     children.map((child, i) => (
@@ -81,6 +93,41 @@ const ItaliaBlocksHtmlRenderers = {
     children.map((child, i) => (
       <p id={keys[i]} key={keys[i]} className="text-center">
         {renderHTMLBlock(child)}
+      </p>
+    )),
+  'lighthouse_appointment-booking': (children, { keys }) =>
+    children.map((child, i) => (
+      <p id={keys[i]} key={keys[i]} className="lighthouse_appointment-booking">
+        {renderHTMLBlock(child)}
+        {renderDataElement('appointment-booking')}
+      </p>
+    )),
+  lighthouse_faq: (children, { keys }) =>
+    children.map((child, i) => (
+      <p id={keys[i]} key={keys[i]} className="lighthouse_faq">
+        {renderHTMLBlock(child)}
+        {renderDataElement('faq')}
+      </p>
+    )),
+  'lighthouse_report-inefficency': (children, { keys }) =>
+    children.map((child, i) => (
+      <p id={keys[i]} key={keys[i]} className="lighthouse_report-inefficency">
+        {renderHTMLBlock(child)}
+        {renderDataElement('report-inefficency')}
+      </p>
+    )),
+  'lighthouse_accessibility-link': (children, { keys }) =>
+    children.map((child, i) => (
+      <p id={keys[i]} key={keys[i]} className="lighthouse_accessibility-link">
+        {renderHTMLBlock(child)}
+        {renderDataElement('accessibility-link')}
+      </p>
+    )),
+  'lighthouse_privacy-policy-link': (children, { keys }) =>
+    children.map((child, i) => (
+      <p id={keys[i]} key={keys[i]} className="lighthouse_privacy-policy-link">
+        {renderHTMLBlock(child)}
+        {renderDataElement('privacy-policy-link')}
       </p>
     )),
   'align-right': (children, { keys }) =>

--- a/src/config/RichTextEditor/config.js
+++ b/src/config/RichTextEditor/config.js
@@ -41,8 +41,6 @@ const ItaliaRichTextEditorInlineToolbarButtons = (props, plugins) => {
     UnderlineButton(props),
     TextSizeButton(props),
     Separator,
-    Lighthouse,
-    Separator,
     HeadingsButton(props),
     linkPlugin.LinkButton,
     ButtonsButton(props),
@@ -51,6 +49,8 @@ const ItaliaRichTextEditorInlineToolbarButtons = (props, plugins) => {
     OrderedListButton,
     BlockquoteButton,
     CalloutsButton(props),
+    Separator,
+    Lighthouse,
   ];
 };
 


### PR DESCRIPTION
[US33941](https://redturtle.tpondemand.com/entity/33941-adeguare-lhmtl-secondo-le-direttive-per)

Added a button to draftjs toolbar to select a data-element inside a link. This option is showed only when both option, "link" and "lighthouse", are selected 

Select options:
"Prenotazione appuntamento" -> produce sul link data-element="appointment-booking"
"Domande frequenti" -> produce sul link data-element="faq"
"Segnalazione disservizio" -> produce sul link data-element="report-inefficency"
"Dichiarazione di accessibilità" -> produce sul link data-element="accessibility-link" 
"Informativa privacy" -> produce sul link data-element="privacy-policy-link" 

To add the data-element to the link it was necessary add a function to push it inside the tag <a> because the constructor of this element wasn't accessible.

<img width="653" alt="Schermata 2022-11-22 alle 09 41 35" src="https://user-images.githubusercontent.com/60133113/203266512-03f8689e-4275-4cd0-9d97-4aa124062141.png">
